### PR TITLE
IP forwarding is not enabled by default on newest boot2docker 

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ bash <(curl -fsSL https://raw.githubusercontent.com/sparkfabrik/sparkdock/master
 
 ### Ubuntu
 
-We are currently supporting all versions from 14.04 LTS up to 18.04 LTS.  
-18.04 support is finally stable (but for docker, read on) and the installation procedure is now totally uninstrusive on systems that ships with `systemd-resolved` (namely 17.04+).  
+We are currently supporting all versions from 14.04 LTS up to 18.04 LTS.
+18.04 support is finally stable (but for docker, read on) and the installation procedure is now totally uninstrusive on systems that ships with `systemd-resolved` (namely 17.04+).
 The new installer automatically selects the correct packages and configurations for your OS version.
 
-**Important note on docker**: due to [some delay in releasing a stable bionic package](https://github.com/docker/for-linux/issues/290) we are relying on `test` official repo channel. This means ATTOW we are running `docker-ce 18.05rc1`. If you experience any issue, please change your repository back to `artful stable`.  
+**Important note on docker**: due to [some delay in releasing a stable bionic package](https://github.com/docker/for-linux/issues/290) we are relying on `test` official repo channel. This means ATTOW we are running `docker-ce 18.05rc1`. If you experience any issue, please change your repository back to `artful stable`.
 Stable support will be available as soon as available (probably in june 2018).
 
 To install just issue
@@ -68,22 +68,29 @@ If something goes awry, please:
 * Check if dnsdock container is running `docker ps | grep dnsdock`
 * Check dinghy services, you should see something like this:
 
-```
+```bash
 ❯ dinghy status
    VM: running
   NFS: running
  FSEV: running
   DNS: stopped
 PROXY: stopped
-
 ```
+
 * Clear the system DNS cache with the following commands:
 
-```
+```bash
 sudo dscacheutil -flushcache
 sudo killall -HUP mDNSResponder
 ```
 
+* Enable IP forwarding inside dinghy
+
+If you restarted dinghy, either by `dinghy restart` or by `dinghy stop && dinghy up`, you should enable the IP forwarding. We do this on the startup of the OS, in the  launchctl script, but if the machine is restarted we should enable it again.
+
+```bash
+docker-machine ssh dinghy sudo iptables -P FORWARD ACCEPT
+```
 
 ### MacOSX filesytem events
 

--- a/ansible/macosx.yml
+++ b/ansible/macosx.yml
@@ -27,7 +27,6 @@
     - name: Install docker binaries with brew.
       shell: "{{ item }}"
       with_items:
-        - "brew install {{ docker_hash }}"
         - "brew install {{ docker_compose_hash }}"
         - "brew install docker-machine"
 

--- a/bin/install.macosx
+++ b/bin/install.macosx
@@ -71,6 +71,12 @@ then
   unset DOCKER_CERT_PATH DOCKER_HOST DOCKER_MACHINE DOCKER_TLS_VERIFY
   ansible-playbook /usr/local/dev-env/ansible/macosx.yml -i 127.0.0.1 --extra-vars "VM_RAM=$RAM  VM_DISK=$DISK" --ask-become-pass -v
 
+  ## Ensure IP forwarding within the dinghy machine. ##
+  echo -e "\n"
+  echo -e "Adding IP forwarding within the dinghy machine."
+  echo -e "> docker-machine ssh dinghy sudo iptables -P FORWARD ACCEPT"
+  docker-machine ssh dinghy sudo iptables -P FORWARD ACCEPT
+
   ## Configure dotrc message.
   echo -e "\n"
   echo -e "Now remember to add to your .bashrc or .zshrc the following command:\n"

--- a/config/macosx/run-machine.sh
+++ b/config/macosx/run-machine.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 dinghy up
+docker-machine ssh dinghy sudo iptables -P FORWARD ACCEPT
 sudo route -n add -net 172.16.0.0/12 $(docker-machine ip dinghy)
 /usr/local/bin/fsevent-start


### PR DESCRIPTION
This should fix #22 

I've removed the installation of docker to let brew decide the most appropriate dependency for the version of docker-compose we are installing. This should fix the cases where brew complains about the fact that docker in already installed when installing compose.