### PR TITLE
remove docker-completion from ansible script

### DIFF
--- a/ansible/macos/macos12/base.yml
+++ b/ansible/macos/macos12/base.yml
@@ -20,7 +20,6 @@
         community.general.homebrew:
           name:
             - awscli
-            - docker-completion
             - docker-compose
             - docker-credential-helper-ecr
             - imagemagick


### PR DESCRIPTION
The package is already included in docker:

```
Error: Cannot install docker-completion because conflicting formulae are installed.
  docker: because docker already includes these completion scripts
```