### PR TITLE
Improvements to Ubuntu playbook

### DIFF
--- a/ansible/ubuntu/ubuntu20.yml
+++ b/ansible/ubuntu/ubuntu20.yml
@@ -10,6 +10,12 @@
     dev_env_dir: /tmp/dev-env
 
   tasks:
+
+    - name: get the username running the deploy
+      become: false
+      local_action: command whoami
+      register: local_username
+
     - name: Install the base required dependencies and suggested packages
       apt:
         pkg:
@@ -23,7 +29,7 @@
         update_cache: yes
 
     - name: Allow current user to execute docker commands
-      user: name={{ ansible_user }} groups=docker append=yes
+      user: name={{ local_username }} groups=docker append=yes
 
     - name: Check if docker-compose binary exists
       stat: path=/usr/local/bin/docker-compose

--- a/ansible/ubuntu/ubuntu20.yml
+++ b/ansible/ubuntu/ubuntu20.yml
@@ -23,7 +23,7 @@
         update_cache: yes
 
     - name: Allow current user to execute docker commands
-      user: name={{ ansible_ssh_user }} groups=docker append=yes
+      user: name={{ ansible_user }} groups=docker append=yes
 
     - name: Check if docker-compose binary exists
       stat: path=/usr/local/bin/docker-compose

--- a/ansible/ubuntu/ubuntu20.yml
+++ b/ansible/ubuntu/ubuntu20.yml
@@ -61,29 +61,37 @@
       service: name=systemd-resolved state=restarted
 
     - name: Copy dnsdock start script
-      file:
+      copy:
         src: "{{ dev_env_dir }}/config/ubuntu/bin/run-dnsdock"
         dest: /usr/local/bin/run-dnsdock
-        state: link
+        owner: root
+        group: root
+        mode: '0755'
         force: yes
 
     - name: Copy dnsdock test script
-      file:
+      copy:
         src: "{{ dev_env_dir }}/config/bin/test-dnsdock"
         dest: /usr/local/bin/test-dnsdock
-        state: link
+        owner: root
+        group: root
+        mode: '0755'
         force: yes
 
     - name: Copy dinghy-http-proxy start script
-      file:
+      copy:
         src: "{{ dev_env_dir }}/config/ubuntu/bin/run-dinghy-proxy"
         dest: /usr/local/bin/run-dinghy-proxy
-        state: link
+        owner: root
+        group: root
+        mode: '0755'
         force: yes
 
     - name: Copy dinghy-http-proxy test script
-      file:
+      copy:
         src: "{{ dev_env_dir }}/config/bin/test-dinghy-proxy"
         dest: /usr/local/bin/test-dinghy-proxy
-        state: link
+        owner: root
+        group: root
+        mode: '0755'
         force: yes

--- a/ansible/ubuntu/ubuntu20.yml
+++ b/ansible/ubuntu/ubuntu20.yml
@@ -11,7 +11,7 @@
 
   tasks:
 
-    - name: get the username running the deploy
+    - name: Getting the username running the provisioner
       become: false
       local_action: command whoami
       register: local_username
@@ -29,7 +29,7 @@
         update_cache: yes
 
     - name: Allow current user to execute docker commands
-      user: name={{ local_username }} groups=docker append=yes
+      user: name={{ local_username.stdout }} groups=docker append=yes
 
     - name: Check if docker-compose binary exists
       stat: path=/usr/local/bin/docker-compose
@@ -37,6 +37,7 @@
 
     - name: Install docker-compose
       shell: "curl -L https://github.com/docker/compose/releases/download/{{ docker_compose_version }}/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose"
+      warn: false
       when: not docker_compose_bin.stat.exists
 
     - name: Create directory for systemd-resolved custom conf

--- a/ansible/ubuntu/ubuntu20.yml
+++ b/ansible/ubuntu/ubuntu20.yml
@@ -5,7 +5,7 @@
   become_user: root
 
   vars:
-    docker_compose_version: 1.25.5
+    docker_compose_version: 1.29.2
     dnsdock_image: aacebedo/dnsdock:v1.16.4-amd64
     dev_env_dir: /tmp/dev-env
 

--- a/ansible/ubuntu/ubuntu20.yml
+++ b/ansible/ubuntu/ubuntu20.yml
@@ -95,3 +95,27 @@
         group: root
         mode: '0755'
         force: yes
+
+    - name: Install google cloud sdk
+      block:
+      - name: Add packages.cloud.google.com PPA key
+        apt_key:
+          url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
+          state: present
+        become: yes
+
+      - name: Add packages.cloud.google.com PPA
+        apt_repository:
+          repo: deb https://packages.cloud.google.com/apt cloud-sdk main
+          filename: google-cloud-sdk
+          state: present
+        become: yes
+
+      - name: Install packages
+        apt:
+          pkg:
+            - google-cloud-sdk
+            - kubectl
+          state: present
+          update_cache: yes
+        become: yes

--- a/ansible/ubuntu/ubuntu20.yml
+++ b/ansible/ubuntu/ubuntu20.yml
@@ -37,7 +37,8 @@
 
     - name: Install docker-compose
       shell: "curl -L https://github.com/docker/compose/releases/download/{{ docker_compose_version }}/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && chmod +x /usr/local/bin/docker-compose"
-      warn: false
+      args:
+        warn: false
       when: not docker_compose_bin.stat.exists
 
     - name: Create directory for systemd-resolved custom conf

--- a/bin/install.ubuntu
+++ b/bin/install.ubuntu
@@ -20,7 +20,7 @@ fi
 
 ## Install base dependencies  ##
 echo "Installing..."
-sudo apt-get updates
+sudo apt-get update
 sudo apt-get -y install git ansible
 echo -e "\n\n"
 

--- a/bin/install.ubuntu
+++ b/bin/install.ubuntu
@@ -2,8 +2,8 @@
 
 ## Check Ubuntu version ##
 echo "Checking for Ubuntu to be a supported version..."
-if ! [[ $( lsb_release -rs ) =~ ^(14\.04|15\.10|16\.04|16.10|17.04|17.10|18.04|20.04)$ ]] ; then
-   echo "This script is supposed to be executed on a version of Ubuntu Linux between 14.04 LTS and 20.04 LTS. Please use a supported version."
+if ! [[ $( lsb_release -rs ) =~ ^(14\.04|15\.10|16\.04|16.10|17.04|17.10|18.04|20.04|22.04)$ ]] ; then
+   echo "This script is supposed to be executed on a version of Ubuntu Linux between 14.04 LTS and 22.04 LTS. Please use a supported version."
    exit 0
 fi
 echo -e "\n\n"

--- a/bin/install.ubuntu
+++ b/bin/install.ubuntu
@@ -9,7 +9,7 @@ fi
 echo -e "\n\n"
 
 ## Add ansible PPA for versions < 20.04.
-if [[ $(lsb_release -rs) != "20.04" ]]; then
+if [[ $(lsb_release -rs) != "20.04" && $(lsb_release -rs) != "22.04" ]]; then
 echo "Add PPA repository for Ubuntu < 20.04."
 which -s ansible-playbook
 if [[ $? != 0 ]] ; then


### PR DESCRIPTION
This MR brings the following improvements and fixes to Ubuntu installation:

- FIX: dnsdock+dinghy run and test scripts are copied over from `/tmp` instead of symlinked (getting lost after a reboot)
- FIX: fixed a typo that made apt update fail in the execution script
- IMPR: docker-compose is upgraded to 1.29.2, which I discovered is required by some recent projects
- IMPR: Google Cloud SDK is installed automatically, as in the Mac provisioner (required during onboarding procedures)
- IMPR: Local user name detection is now a bit more reliable than previous `ansible_ssh_user` which has been deprecated (using local whoami command output in the playbook)
- IMPR: introduced support for 22.04 LTS1

I successfully tested this provisioner on a brand new Ubuntu 22.04 LTS installation, on a laptop from a local branch. I hope the necessary automation is still working when the changes are on master (they should), but I'm ready to test it out and check on a fresh installation as soon as it's merged.

I also succesfully checked the onboarding procedure and a project build.

This brings in the minimum set of tools necessary to succesfully complete the technical onboarding and build/run a project locally.