### PR TITLE
Adds missing package for GCloud Auth login

### DIFF
--- a/ansible/ubuntu/ubuntu20.yml
+++ b/ansible/ubuntu/ubuntu20.yml
@@ -123,6 +123,7 @@
         apt:
           pkg:
             - google-cloud-sdk
+            - google-cloud-sdk-gke-gcloud-auth-plugin
             - kubectl
           state: present
           update_cache: yes


### PR DESCRIPTION
Sibling of https://github.com/sparkfabrik/sparkdock/pull/53.

This repo may be deprecated, but I brought it up to 22.04 so it's working ATM. Adding this to maintain it while I update the other repo.