### PR TITLE
refs: Add missing sleep command to test-dinghy-proxy

### DIFF
--- a/config/bin/test-dinghy-proxy
+++ b/config/bin/test-dinghy-proxy
@@ -5,6 +5,7 @@ GREEN='\033[0;32m'
 NC='\033[0m'
 
 ID=$(docker run -d -e VIRTUAL_HOST=nginx.sparkfabrik.loc nginx:alpine)
+sleep 5
 CONTENT=$(curl -s nginx.sparkfabrik.loc)
 echo ${CONTENT} | grep -q 'Welcome to nginx'
 if [ $? -eq 0 ]


### PR DESCRIPTION
A few days ago I noticed that on my MacBook the script "test-dinghy-proxy" was always failing, even though I knew for certain that Dinghy was working correctly on my machine. After some digging, I noticed that the "test-dnsdock" script had a single extra crucial command: "sleep 5".

I manually added the command to "test-dinghy-proxy" and it started working right away!