### PR TITLE
refs: Update dinghy image to 2.7.1

### DIFF
--- a/config/macos/bin/run-dinghy-proxy
+++ b/config/macos/bin/run-dinghy-proxy
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 echo "Starting a dinghy-http-proxy container..."
-IMAGE=codekitchen/dinghy-http-proxy:2.7.0
+IMAGE=codekitchen/dinghy-http-proxy:2.7.1
 docker pull ${IMAGE}
 docker rm -vf http-proxy || true
 docker run -d --restart=always \

--- a/config/ubuntu/bin/run-dinghy-proxy
+++ b/config/ubuntu/bin/run-dinghy-proxy
@@ -11,7 +11,7 @@ if docker ps -a | grep 'dinghy-http-proxy' > /dev/null; then
 fi
 
 echo "Now starting a new dinghy-http-proxy container..."
-IMAGE=codekitchen/dinghy-http-proxy:2.7.0
+IMAGE=codekitchen/dinghy-http-proxy:2.7.1
 docker pull ${IMAGE}
 docker run --restart=always -d -v /var/run/docker.sock:/var/run/docker.sock \
 -e DNS_IP=127.0.0.1 \


### PR DESCRIPTION
There is a new minor version of "codekitchen/dinghy-http-proxy": 2.7.1 (we are still using the 2.7.0). It was released almost a [year ago](https://github.com/codekitchen/dinghy-http-proxy/releases/tag/2.7.1).

I manually updated dinghy on my machine and everything works as expected.