### PR TITLE
Add MonitorControl to brew packages

### DIFF
--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -115,6 +115,7 @@
           - visual-studio-code
           - slack
           - zoom
+          - MonitorControl
         state: present
         install_options: force
 


### PR DESCRIPTION
Controls your external display brightness and volume and shows native OSD