### PR TITLE
refs: Update dnsdock image to 1.17.0

### DIFF
--- a/ansible/ubuntu/ubuntu20.yml
+++ b/ansible/ubuntu/ubuntu20.yml
@@ -6,7 +6,7 @@
 
   vars:
     docker_compose_version: 1.29.2
-    dnsdock_image: aacebedo/dnsdock:v1.16.4-amd64
+    dnsdock_image: aacebedo/dnsdock:v1.17.0-amd64
     dev_env_dir: /tmp/dev-env
 
   tasks:

--- a/config/ubuntu/bin/run-dnsdock
+++ b/config/ubuntu/bin/run-dnsdock
@@ -1,5 +1,5 @@
 #!/bin/bash
-DNSDOCK_VERSION=${1:-aacebedo\/dnsdock:v1.16.4-amd64}
+DNSDOCK_VERSION=${1:-aacebedo\/dnsdock:v1.17.0-amd64}
 if docker ps -a | grep 'dnsdock' > /dev/null; then
     echo -n "Found a dnsdock container, removing it..."
     docker rm -vf dnsdock 1> /dev/null


### PR DESCRIPTION
The new minor update for dnsdock adds support for the latest Docker's API. See more information about it here: https://github.com/aacebedo/dnsdock/issues/107.

EDIT: I forgot to mention that I tested the updated image on my Ubuntu machine with Docker 25.0.0 and everything works again!