### PR TITLE
refs: Add certs dinghy linux

### DIFF
--- a/config/macos/bin/run-dinghy-proxy
+++ b/config/macos/bin/run-dinghy-proxy
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+
+# The certs are only red by dinghy on startup.
+# Rerun the script to update the certs.
+mkdir -p ~/.dinghy/certs
+
 echo "Starting a dinghy-http-proxy container..."
 IMAGE=codekitchen/dinghy-http-proxy:2.7.1
 docker pull ${IMAGE}

--- a/config/ubuntu/bin/run-dinghy-proxy
+++ b/config/ubuntu/bin/run-dinghy-proxy
@@ -10,10 +10,15 @@ if docker ps -a | grep 'dinghy-http-proxy' > /dev/null; then
     docker rm -vf dinghy-http-proxy 1> /dev/null
 fi
 
+# The certs are only red by dinghy on startup.
+# Rerun the script to update the certs.
+mkdir -p ~/.dinghy/certs
+
 echo "Now starting a new dinghy-http-proxy container..."
 IMAGE=codekitchen/dinghy-http-proxy:2.7.1
 docker pull ${IMAGE}
 docker run --restart=always -d -v /var/run/docker.sock:/var/run/docker.sock \
+-v ~/.dinghy/certs:/etc/nginx/certs \
 -e DNS_IP=127.0.0.1 \
 -e CONTAINER_NAME=dinghy-http-proxy \
 -e DOMAIN_TLD=loc \


### PR DESCRIPTION
I just noticed that the dinghy script on Linux does not have the options for reading the certs. I added it following the documentation (it's the very same argument already there on the macOS version).

I also added the auto generation for that path, since it would be created with root permission by dinghy, if not available already.