### PR TITLE
feat: use a more intelligent regexp

### DIFF
--- a/ansible/macos.yml
+++ b/ansible/macos.yml
@@ -4,14 +4,6 @@
   become: true
   become_user: root
 
-- name: Importing playbook for macOS 14
+- name: Import playbook for macOS
   import_playbook: macos/macos/base.yml
-  when: ansible_distribution_version | regex_search('^(14.[0-9]+)')
-
-- name: Importing playbook for macOS 13
-  import_playbook: macos/macos/base.yml
-  when: ansible_distribution_version | regex_search('^(13.[0-9]+)')
-
-- name: Importing playbook for macOS 12
-  import_playbook: macos/macos/base.yml
-  when: ansible_distribution_version | regex_search('^(12.[0-9]+)')
+  when: ansible_distribution_version | regex_search('^(1[2-5].[0-9]+)')


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Simplified the macOS playbook import process by using a more intelligent regular expression
- Consolidated multiple version-specific imports into a single, more inclusive import
- Updated regex to support macOS versions 12 through 15, allowing for future compatibility
- Reduced code duplication and improved maintainability by removing redundant playbook imports
- Improved overall efficiency of the Ansible playbook for macOS configurations


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>macos.yml</strong><dd><code>Streamline macOS playbook import with improved version detection</code></dd></summary>
<hr>

ansible/macos.yml

<li>Simplified playbook import for macOS versions 12-15<br> <li> Replaced multiple version-specific imports with a single import using <br>a more inclusive regex<br> <li> Removed redundant playbook imports for individual macOS versions<br>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/88/files#diff-74eaffaddb7e6ee392f81e5060f6bea50b791cdb80f2292b2257c744fb4e0e38">+2/-10</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

