### PR TITLE
feat: use a more intelligent regexp

### DIFF
--- a/ansible/macos.yml
+++ b/ansible/macos.yml
@@ -6,4 +6,4 @@
 
 - name: Import playbook for macOS
   import_playbook: macos/macos/base.yml
-  when: ansible_distribution_version | regex_search('^(1[2-5].[0-9]+)')
+  when: ansible_distribution_version | regex_search('^(1[2-5]\.[0-9]+)')

--- a/ansible/macos.yml
+++ b/ansible/macos.yml
@@ -6,4 +6,5 @@
 
 - name: Import playbook for macOS
   import_playbook: macos/macos/base.yml
+  # Match macOS versions 12.0 through 15.x
   when: ansible_distribution_version | regex_search('^(1[2-5]\.[0-9]+)')


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Enhanced the regular expression used for matching macOS version numbers in the `ansible/macos.yml` playbook
- Fixed a potential issue where the previous regex might not correctly match all valid macOS version numbers
- Improved the reliability of the playbook by ensuring it runs on the intended macOS versions (12.x to 15.x)
- The change involves adding an escaped dot (`\.`) in the regex pattern to strictly match the version number format


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>macos.yml</strong><dd><code>Improve macOS version regex matching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ansible/macos.yml

<li>Updated the regular expression in the <code>when</code> condition for importing the <br>macOS playbook<br> <li> Fixed the regex pattern to correctly match macOS version numbers<br>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/89/files#diff-74eaffaddb7e6ee392f81e5060f6bea50b791cdb80f2292b2257c744fb4e0e38">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

