### PR TITLE
feat: move install update logic in the skip-update flow

### DIFF
--- a/bin/sparkdock.macos
+++ b/bin/sparkdock.macos
@@ -50,6 +50,9 @@ notify() {
     osascript -e "display notification \"$1\" with title \"Sparkdock\""
 }
 
+# Install/update the launchd service first
+install_update_service
+
 # Version command
 if [ "$1" = "version" ] ; then
     get_version_info
@@ -83,10 +86,6 @@ if [ "$1" != "skip-update" ] ; then
         git reset --hard "$CURRENT_VERSION"
         exit 1
     fi
-
-    # Install/update the launchd service before executing the update
-    print "Installing/updating update checker service..."
-    install_update_service
 
     $0 skip-update
     exit $?


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Restructured the update flow in sparkdock.macos by moving the launchd service installation to execute first, before any other operations
- Removed redundant logging message for service installation/update
- Simplified the update logic flow by ensuring service is always installed upfront
- Improves reliability by handling service installation independently of update process



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sparkdock.macos</strong><dd><code>Reorder service installation in update flow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bin/sparkdock.macos

<li>Moved <code>install_update_service</code> call outside the update flow to execute <br>first<br> <li> Removed redundant print message for service installation<br> <li> Simplified update logic flow by moving service installation to start


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/93/files#diff-6041c609d655c940b8651eed16a67ad8ae322b025b7c89688500cad43e130528">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information