### PR TITLE
fix: check updates exit status

### DIFF
--- a/bin/sparkdock.macos
+++ b/bin/sparkdock.macos
@@ -83,9 +83,9 @@ fi
 if [ "$1" = "check-updates" ] ; then
     if check_for_updates; then
         notify "Updates are available. Run 'sparkdock' to update your system."
-        exit 0
+        exit 0  # Updates available
     fi
-    exit 0
+    exit 1  # No updates available
 fi
 
 # Updating myself.


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix exit status for `check-updates` command

- Return exit code 1 when no updates available

- Return exit code 0 when updates are available

- Add clarifying comments for exit status codes


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sparkdock.macos</strong><dd><code>Fix check-updates exit status handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bin/sparkdock.macos

<li>Modified exit status for no updates case from 0 to 1<br> <li> Added comments clarifying exit codes for updates availability<br> <li> Maintained exit 0 for updates available case


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/123/files#diff-6041c609d655c940b8651eed16a67ad8ae322b025b7c89688500cad43e130528">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>