### PR TITLE
feat: just print version

### DIFF
--- a/bin/common/utils.sh
+++ b/bin/common/utils.sh
@@ -62,16 +62,9 @@ get_version_info() {
     fi
     cd /opt/sparkdock
     local current_branch=$(git rev-parse --abbrev-ref HEAD)
-    local local_version=$(git rev-parse --short HEAD)
+    local current_version=$(git rev-parse --short HEAD)
     local last_commit_date=$(git log -1 --format=%cd --date=format:'%Y-%m-%d %H:%M:%S')
-
-    # Get remote version (fetch quietly to get latest remote info)
-    local remote_version="unknown"
-    if git fetch origin "${current_branch}" -q 2>/dev/null; then
-        remote_version=$(git rev-parse --short "origin/${current_branch}" 2>/dev/null || echo "unknown")
-    fi
-    echo "Local version: ${local_version} (${current_branch})"
-    echo "Remote version: ${remote_version} (${current_branch})"
+    echo "Version: ${current_version} (${current_branch})"
     echo "Last commit: ${last_commit_date}"
     echo "Last update: $(get_last_update)"
 }


### PR DESCRIPTION
### **User description**
closes #140


___

### **PR Type**
Bug fix


___

### **Description**
- Simplify version display to show single current version

- Remove remote version fetching that always matched local

- Fix misleading version information in system banner

- Rename variable from `local_version` to `current_version`


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.sh</strong><dd><code>Simplify version display logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bin/common/utils.sh

<li>Remove remote version fetching logic that always matched local version<br> <li> Simplify output to show single version instead of local/remote pair<br> <li> Rename <code>local_version</code> variable to <code>current_version</code> for clarity<br> <li> Remove git fetch operation that was causing confusion


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/142/files#diff-0e519661e53f442cf4e168f2abea58548b5f1c9358f55fc54b6fc77363c56a33">+2/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>