### PR TITLE
fix: better check-updates logging

### DIFF
--- a/bin/sparkdock.macos
+++ b/bin/sparkdock.macos
@@ -45,8 +45,11 @@ check_for_updates() {
     REMOTE=$(git rev-parse origin/${DEFAULT_BRANCH})
 
     if [ "$LOCAL" != "$REMOTE" ]; then
-        echo "Updates available:"
-        git --no-pager log --oneline HEAD..origin/${DEFAULT_BRANCH}
+        DIFF=$(git --no-pager log --oneline HEAD..origin/${DEFAULT_BRANCH})
+        if [ -n "$DIFF" ]; then
+            echo "Updates available:"
+            echo "$DIFF"
+        fi
         return 0
     fi
     return 1


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Improved update checking logic in macOS script

- Added validation for git log output

- Enhanced logging reliability for available updates

- Fixed potential empty output display issues


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sparkdock.macos</strong><dd><code>Improve update checking output validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bin/sparkdock.macos

<li>Store git log output in <code>DIFF</code> variable before displaying<br> <li> Add check to ensure <code>DIFF</code> is not empty before showing updates<br> <li> Prevent display of empty update messages


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/163/files#diff-6041c609d655c940b8651eed16a67ad8ae322b025b7c89688500cad43e130528">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>