### PR TITLE
Add preflight-check for cask packages to prevent manual installation conflicts

### DIFF
--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -23,6 +23,12 @@
         name: all_packages
       tags: always
 
+    - name: Load cask to app name mappings
+      include_vars:
+        file: "{{ dev_env_dir }}/config/packages/cask-app-names.yml"
+        name: cask_mappings
+      tags: always
+
     - name: Collect all package lists
       tags: brew_packages
       set_fact:
@@ -104,31 +110,65 @@
       when: all_removed_homebrew | length > 0
       become: false
 
-    - name: Docker and container runtime installation
-      tags: [docker]
+    - name: Preflight check for cask packages
+      tags: cask
       block:
-        - name: Check if Docker Desktop is already installed
-          shell: brew list --cask docker-desktop >/dev/null 2>&1 && echo yes || echo no
-          register: docker_desktop_installed
+        - name: Check which cask packages are already installed via Homebrew
+          shell: |
+            for pkg in {{ all_cask_packages | map('quote') | join(' ') }}; do
+              if brew list --cask "$pkg" >/dev/null 2>&1; then
+                echo "$pkg:brew"
+              fi
+            done
+          register: homebrew_cask_check
           changed_when: false
+          become: false
 
-        - name: Remove Docker Desktop from install list if already installed
-          set_fact:
-            all_cask_packages: "{{ all_cask_packages | difference(['docker-desktop']) }}"
-          when: "'docker-desktop' in all_cask_packages and docker_desktop_installed.stdout == 'yes'"
-
-    - name: Google Chrome installation
-      tags: [chrome]
-      block:
-        - name: Check if Google Chrome is already installed
-          shell: brew list --cask google-chrome >/dev/null 2>&1 && echo yes || echo no
-          register: google_chrome_installed
+        - name: Check which cask packages are manually installed
+          shell: |
+            {% for cask in all_cask_packages %}
+            {% if cask in cask_mappings.cask_to_app_mapping %}
+            if [ -d "/Applications/{{ cask_mappings.cask_to_app_mapping[cask] }}" ]; then
+              if ! brew list --cask {{ cask }} >/dev/null 2>&1; then
+                echo "{{ cask }}:manual"
+              fi
+            fi
+            {% endif %}
+            {% endfor %}
+          register: manual_cask_check
           changed_when: false
+          become: false
 
-        - name: Remove Google Chrome from install list if already installed
+        - name: Parse installation status
           set_fact:
-            all_cask_packages: "{{ all_cask_packages | difference(['google-chrome']) }}"
-          when: "'google-chrome' in all_cask_packages and google_chrome_installed.stdout == 'yes'"
+            homebrew_installed_casks: "{{ homebrew_cask_check.stdout_lines | map('regex_replace', ':brew$', '') | list }}"
+            manually_installed_casks: "{{ manual_cask_check.stdout_lines | map('regex_replace', ':manual$', '') | list }}"
+
+        - name: Display warning for manually installed applications
+          debug:
+            msg:
+              - "⚠️  WARNING: The following applications are installed manually (not via Homebrew):"
+              - "{{ manually_installed_casks | join(', ') }}"
+              - ""
+              - "These will be SKIPPED during installation to avoid conflicts."
+              - ""
+              - "📋 Recommendation: For better package management, consider:"
+              - "   1. Uninstalling the manually installed applications"
+              - "   2. Re-running sparkdock to install them via Homebrew"
+              - ""
+              - "This ensures all applications are managed consistently through Homebrew."
+          when: manually_installed_casks | length > 0
+
+        - name: Remove already-installed casks from installation list
+          set_fact:
+            all_cask_packages: "{{ all_cask_packages | difference(homebrew_installed_casks) | difference(manually_installed_casks) }}"
+
+        - name: Display casks to be installed
+          debug:
+            msg:
+              - "📦 Cask packages to be installed: {{ all_cask_packages | length }}"
+              - "{{ all_cask_packages | join(', ') if all_cask_packages | length > 0 else 'None (all already installed)' }}"
+          when: ansible_verbosity >= 0
 
     - name: Install cask packages
       tags: cask

--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -113,11 +113,20 @@
     - name: Preflight check for cask packages
       tags: cask
       block:
+        - name: Get all installed casks from Homebrew (single call optimization)
+          shell: brew list --cask 2>/dev/null || true
+          register: all_installed_casks
+          changed_when: false
+          become: false
+
         - name: Check which cask packages are already installed via Homebrew
           shell: |
+            # Use cached list of installed casks
+            installed_casks="{{ all_installed_casks.stdout }}"
+
             for pkg in {{ all_cask_packages | map('quote') | join(' ') }}; do
-              if brew list --cask "$pkg" >/dev/null 2>&1; then
-                echo "$pkg:brew"
+              if echo "$installed_casks" | grep -qx "$pkg"; then
+                echo "$pkg"
               fi
             done
           register: homebrew_cask_check
@@ -126,11 +135,14 @@
 
         - name: Check which cask packages are manually installed
           shell: |
+            # Use cached list of installed casks
+            installed_casks="{{ all_installed_casks.stdout }}"
+
             {% for cask in all_cask_packages %}
             {% if cask in cask_mappings.cask_to_app_mapping %}
             if [ -d "/Applications/{{ cask_mappings.cask_to_app_mapping[cask] }}" ]; then
-              if ! brew list --cask {{ cask }} >/dev/null 2>&1; then
-                echo "{{ cask }}:manual"
+              if ! echo "$installed_casks" | grep -qx "{{ cask }}"; then
+                echo "{{ cask }}"
               fi
             fi
             {% endif %}
@@ -141,8 +153,8 @@
 
         - name: Parse installation status
           set_fact:
-            homebrew_installed_casks: "{{ homebrew_cask_check.stdout_lines | map('regex_replace', ':brew$', '') | list }}"
-            manually_installed_casks: "{{ manual_cask_check.stdout_lines | map('regex_replace', ':manual$', '') | list }}"
+            homebrew_installed_casks: "{{ homebrew_cask_check.stdout_lines }}"
+            manually_installed_casks: "{{ manual_cask_check.stdout_lines }}"
 
         - name: Display warning for manually installed applications
           debug:

--- a/config/packages/cask-app-names.yml
+++ b/config/packages/cask-app-names.yml
@@ -1,0 +1,17 @@
+# Mapping of Homebrew cask package names to their Application bundle names
+# This file is used by the preflight-check to detect manually installed applications
+# Format: cask_package_name: "Application Name.app"
+#
+# Only include casks that:
+# 1. Are commonly installed manually by users
+# 2. Cause installation conflicts when already present
+# 3. Have standard installation paths in /Applications
+
+cask_to_app_mapping:
+  google-chrome: "Google Chrome.app"
+  docker-desktop: "Docker.app"
+  visual-studio-code: "Visual Studio Code.app"
+  slack: "Slack.app"
+  zoom: "zoom.us.app"
+  iterm2: "iTerm.app"
+  ghostty: "Ghostty.app"

--- a/config/packages/cask-app-names.yml
+++ b/config/packages/cask-app-names.yml
@@ -6,6 +6,9 @@
 # 1. Are commonly installed manually by users
 # 2. Cause installation conflicts when already present
 # 3. Have standard installation paths in /Applications
+# 
+# Do NOT include casks that are rarely installed manually or have no known conflict issues.
+# Example: Do not include utility casks that are typically installed as dependencies and do not conflict with manual installations.
 
 cask_to_app_mapping:
   google-chrome: "Google Chrome.app"


### PR DESCRIPTION
### **User description**
## Summary

Implements a generic preflight-check system that detects both Homebrew-managed and manually-installed cask applications before attempting installation.

## Changes

- Add `config/packages/cask-app-names.yml` mapping cask names to app bundles
- Replace individual Docker/Chrome checks with unified preflight system
- Check both brew installations and /Applications directory
- Display clear warnings for manually-installed apps
- Skip conflicting packages to prevent permission errors

Fixes #268

---
🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Implemented generic preflight-check system for cask packages to detect both Homebrew and manual installations

- Added `cask-app-names.yml` mapping file for cask-to-app bundle name translations

- Replaced individual Docker/Chrome checks with unified detection logic

- Added user-friendly warnings for manually-installed apps with skip behavior to prevent permission errors


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Load cask mappings"] --> B["Check Homebrew installations"]
  B --> C["Check manual installations"]
  C --> D["Parse installation status"]
  D --> E["Display warnings"]
  E --> F["Remove conflicts from install list"]
  F --> G["Install remaining casks"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base.yml</strong><dd><code>Implement unified preflight-check system for cask packages</code></dd></summary>
<hr>

ansible/macos/macos/base.yml

<ul><li>Added task to load <code>cask-app-names.yml</code> mapping file<br> <li> Replaced individual Docker/Chrome checks with unified preflight-check <br>block<br> <li> Implemented detection for both Homebrew-managed and manually-installed <br>cask packages<br> <li> Added warning messages for manually-installed apps and automatic skip <br>logic</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/271/files#diff-35e06808caf91480daa0d30bc6b6a1e4c425376bb5d3196d021dca2357bdd621">+58/-18</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cask-app-names.yml</strong><dd><code>Add cask-to-app bundle name mapping configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/packages/cask-app-names.yml

<ul><li>Created mapping file for cask package names to Application bundle <br>names<br> <li> Includes common applications like Chrome, Docker, VS Code, Slack, <br>Zoom, iTerm2, and Ghostty</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/271/files#diff-a608de75fb02054aeb85106855a18ccc88b7beacab5fc534482c4e4b9f688e85">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

