### PR TITLE
Fix duplicated git safe directory rule

### DIFF
--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -341,16 +341,31 @@
       become_method: sudo
 
     - name: Configure git safe directory for sparkdock
-      command: git config --global --add safe.directory "{{ dev_env_dir }}"
-      become: no
       tags: [always]
+      become: no
+      block:
+        - name: Check if sparkdock is already in git safe.directory
+          shell: git config --global --get-all safe.directory | grep -Fx "{{ dev_env_dir }}" || true
+          register: sparkdock_safe_dir_check
+          changed_when: false
+
+        - name: Add sparkdock to git safe.directory
+          command: git config --global --add safe.directory "{{ dev_env_dir }}"
+          when: sparkdock_safe_dir_check.stdout == ""
 
     - name: Install system scripts
       tags: http-proxy
       block:
-        - name: Configure git safe directory for http-proxy
+        - name: Check if http-proxy is already in git safe.directory
+          shell: git config --global --get-all safe.directory | grep -Fx "{{ dev_env_dir }}/http-proxy" || true
+          register: http_proxy_safe_dir_check
+          changed_when: false
+          become: no
+
+        - name: Add http-proxy to git safe.directory
           command: git config --global --add safe.directory "{{ dev_env_dir }}/http-proxy"
           become: no
+          when: http_proxy_safe_dir_check.stdout == ""
 
         - name: Ensure /usr/local/bin exists
           file: path=/usr/local/bin state=directory


### PR DESCRIPTION
### **User description**
I noticed that my `.gitconfig` file placed in the home contained multiple times the following rules:

```
[safe]
	directory = /opt/sparkdock
	directory = /opt/sparkdock/http-proxy
	directory = /opt/sparkdock
	directory = /opt/sparkdock/http-proxy
	directory = /opt/sparkdock
	directory = /opt/sparkdock/http-proxy
	directory = /opt/sparkdock
	directory = /opt/sparkdock/http-proxy
	directory = /opt/sparkdock
	directory = /opt/sparkdock/http-proxy
	directory = /opt/sparkdock
	directory = /opt/sparkdock/http-proxy
```

So I added a check for avoiding adding them multiple times. I tested the command with a `.gitconfig` like the one above (it does not add new entries) and also on a config without any safe rules applied (it adds those two correctly).


___

### **PR Type**
Bug fix


___

### **Description**
- Prevent duplicate git safe directory entries in `.gitconfig`

- Add conditional checks before adding safe directory rules

- Check existing safe directories using `git config --get-all`

- Apply fix for both sparkdock and http-proxy directories


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Check existing safe.directory"] --> B{"Entry exists?"}
  B -- "No" --> C["Add safe.directory"]
  B -- "Yes" --> D["Skip addition"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base.yml</strong><dd><code>Add duplicate prevention for git safe directory configuration</code></dd></summary>
<hr>

ansible/macos/macos/base.yml

<ul><li>Added check to verify if sparkdock directory already exists in git <br>safe.directory before adding<br> <li> Added check to verify if http-proxy directory already exists in git <br>safe.directory before adding<br> <li> Restructured tasks into blocks with conditional execution based on <br>existence checks<br> <li> Used <code>git config --get-all</code> with <code>grep -Fx</code> to detect existing entries</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/332/files#diff-35e06808caf91480daa0d30bc6b6a1e4c425376bb5d3196d021dca2357bdd621">+18/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

