### PR TITLE
fix: gcloud-whoami now shows current user when not impersonating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed `c` alias from `clear` to OpenCode main command. Use `clear` command directly or ctrl+l for clearing screen instead
 
 ### Fixed
+- Fixed `gcloud-whoami` not printing the current user when not impersonating a service account
 - Fixed Slack notification system to correctly identify new tool/package additions as significant features (improved prompt clarity to distinguish between dependency version bumps and new capabilities)
 - Fixed `NODE_EXTRA_CA_CERTS` path in copilot function to point to the correct keychain certificate bundle location (`${HOME}/.local/spark/copilot/keychain.pem`)
 - Fixed GitHub Copilot CLI idempotency issue where copilot binary was incorrectly removed on subsequent runs when cask was already installed

--- a/config/shell/aliases.zsh
+++ b/config/shell/aliases.zsh
@@ -128,7 +128,15 @@ fi
 if command_exists gcloud; then
   alias gcloud-as='gcloud config set auth/impersonate_service_account'
   alias gcloud-me='gcloud config unset auth/impersonate_service_account'
-  alias gcloud-whoami='gcloud config get auth/impersonate_service_account 2>/dev/null || echo "none"'
+  gcloud-whoami() {
+    local impersonated
+    impersonated=$(gcloud config get auth/impersonate_service_account 2>/dev/null)
+    if [[ -n "${impersonated}" ]]; then
+      echo "${impersonated}"
+      return
+    fi
+    gcloud auth list --filter=status:ACTIVE --format="value(account)" 2>/dev/null
+  }
 fi
 
 # Add some copilot aliases.


### PR DESCRIPTION
### **User description**
Fixes #340 - `gcloud-whoami` now prints the current authenticated user when not impersonating a service account.

**Root cause:** The alias used `||` fallback which never triggered because `gcloud config get` returns exit code 0 with empty output when the property is unset.

**Fix:** Converted to a function that checks the impersonation value and falls back to `gcloud auth list` to show the active account.

Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed `gcloud-whoami` not showing user when not impersonating

- Converted alias to function with proper empty-string check

- Falls back to `gcloud auth list` for active account display


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["gcloud-whoami called"] -- "check impersonation" --> B["gcloud config get auth/impersonate_service_account"]
  B -- "value is set" --> C["echo impersonated account"]
  B -- "value is empty" --> D["gcloud auth list --filter=status:ACTIVE"]
  D -- "output" --> E["active account printed"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>aliases.zsh</strong><dd><code>Convert gcloud-whoami alias to function with fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/shell/aliases.zsh

<ul><li>Replaced <code>gcloud-whoami</code> alias with a shell function<br> <li> Function checks if impersonation is active via <code>gcloud config get</code><br> <li> Falls back to <code>gcloud auth list</code> to show active account when not <br>impersonating<br> <li> Fixes silent empty output when no service account is impersonated</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/342/files#diff-fe1e4df088c825fe14cb629660151d77d5debec9455646f03c762f2aefb8f03a">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document gcloud-whoami fix in changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

- Added entry under "Fixed" section for `gcloud-whoami` bug fix


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/342/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

