### PR TITLE
fix: resolve Ansible cask reinstall and cert migration errors

### DIFF
--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -221,7 +221,7 @@
       when: all_cask_packages | length > 0
       become: false
       register: cask_force
-      changed_when: "'already registered' not in cask_force.stdout"
+      changed_when: "'already registered' not in stdout"
 
     - name: Assert cask packages installed
       tags: cask
@@ -259,7 +259,6 @@
       loop: "{{ all_homebrew_packages }}"
       when: all_homebrew_packages | length > 0
       become: false
-      ignore_errors: true
 
     - name: Force install unregistered homebrew packages
       tags: brew_packages
@@ -268,7 +267,7 @@
         if brew list "$pkg_name" >/dev/null 2>&1; then
           echo "already installed"
         else
-          brew install "{{ item }}" 2>&1 || true
+          brew install "{{ item }}" 2>&1
         fi
       loop: "{{ all_homebrew_packages }}"
       when: all_homebrew_packages | length > 0

--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -221,7 +221,7 @@
       when: all_cask_packages | length > 0
       become: false
       register: cask_force
-      changed_when: "'already registered' not in stdout"
+      changed_when: "'already registered' not in cask_force.stdout"
 
     - name: Assert cask packages installed
       tags: cask

--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -27,6 +27,7 @@
       tags:
         - brew_packages
         - npm_packages
+        - always
       set_fact:
         all_cask_packages: "{{ all_packages.cask_packages | default([]) }}"
         all_homebrew_packages: "{{ all_packages.homebrew_packages | default([]) }}"
@@ -201,13 +202,29 @@
       community.general.homebrew_cask:
         name: "{{ item }}"
         state: present
-        install_options: force
+        install_options:
+          - force
         sudo_password: "{{ ansible_become_pass | default(omit) }}"
       loop: "{{ all_cask_packages }}"
       when: all_cask_packages | length > 0
       become: false
 
+    - name: Force reinstall unregistered casks
+      tags: cask
+      shell: |
+        if brew list --cask "{{ item }}" >/dev/null 2>&1; then
+          echo "already registered"
+        else
+          brew reinstall --cask --force "{{ item }}" 2>&1
+        fi
+      loop: "{{ all_cask_packages }}"
+      when: all_cask_packages | length > 0
+      become: false
+      register: cask_force
+      changed_when: "'already registered' not in cask_force.stdout"
+
     - name: Assert cask packages installed
+      tags: cask
       shell: |
         missing=0
         for pkg in {{ all_cask_packages | map('quote') | join(' ') }}; do
@@ -242,13 +259,38 @@
       loop: "{{ all_homebrew_packages }}"
       when: all_homebrew_packages | length > 0
       become: false
+      ignore_errors: true
+
+    - name: Force install unregistered homebrew packages
+      tags: brew_packages
+      shell: |
+        pkg_name=$(echo "{{ item }}" | sed 's|.*/||')
+        if brew list "$pkg_name" >/dev/null 2>&1; then
+          echo "already installed"
+        else
+          brew install "{{ item }}" 2>&1 || true
+        fi
+      loop: "{{ all_homebrew_packages }}"
+      when: all_homebrew_packages | length > 0
+      become: false
+      register: brew_force
+      changed_when: "'already installed' not in brew_force.stdout"
+
+    - name: Force link homebrew packages
+      tags: brew_packages
+      shell: brew link --overwrite "{{ item }}" 2>/dev/null || true
+      loop: "{{ all_homebrew_packages }}"
+      when: all_homebrew_packages | length > 0
+      become: false
+      changed_when: false
 
     - name: Assert homebrew packages installed
       tags: brew_packages
       shell: |
         missing=0
         for pkg in {{ all_homebrew_packages | map('quote') | join(' ') }}; do
-          brew list "$pkg" >/dev/null 2>&1 || { echo "$pkg missing"; missing=1; }
+          pkg_name=$(echo "$pkg" | sed 's|.*/||')
+          brew list "$pkg_name" >/dev/null 2>&1 || { echo "$pkg missing"; missing=1; }
         done
         exit $missing
       register: brew_check
@@ -499,6 +541,7 @@
           become_method: sudo
 
         - name: Migrate old dinghy certificates to new location
+          become: false
           block:
             - name: Check if old dinghy certs directory exists
               stat:


### PR DESCRIPTION
### **User description**
- Remove || true from brew reinstall to surface real failures
- Fix changed_when using cask_force.results (aggregate) instead of per-item cask_force.stdout during loop iteration
- Add become: false to cert migration block to prevent permission denied when creating directories in user home


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix cask install options format and add force reinstall for unregistered casks

- Add fallback force install and link steps for homebrew packages

- Fix cert migration block with `become: false` to prevent permission errors

- Add `always` tag to package list collection and fix assertion tag coverage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Install cask packages\n(fixed install_options format)"] -- "if unregistered" --> B["Force reinstall unregistered casks\n(new task)"]
  B -- "verify" --> C["Assert cask packages installed\n(tagged: cask)"]
  D["Install homebrew packages\n(ignore_errors: true)"] -- "if unregistered" --> E["Force install unregistered\nhomebrew packages (new task)"]
  E --> F["Force link homebrew packages\n(new task)"]
  F -- "verify" --> G["Assert homebrew packages installed\n(pkg_name fix)"]
  H["Migrate dinghy certs\n(become: false added)"] --> I["No permission denied\nin user home"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base.yml</strong><dd><code>Fix cask/brew install, force reinstall tasks, and cert migration </code><br><code>permissions</code></dd></summary>
<hr>

ansible/macos/macos/base.yml

<ul><li>Added <code>always</code> tag to "Collect all package lists" task so variables are <br>always available<br> <li> Fixed <code>install_options</code> for homebrew_cask to use list format instead of <br>string<br> <li> Added new "Force reinstall unregistered casks" task using shell with <br>proper <code>changed_when</code><br> <li> Added <code>tags: cask</code> to "Assert cask packages installed" task<br> <li> Added <code>ignore_errors: true</code> to "Install homebrew packages" task<br> <li> Added new "Force install unregistered homebrew packages" and "Force <br>link homebrew packages" tasks<br> <li> Fixed "Assert homebrew packages installed" to extract <code>pkg_name</code> via <code>sed</code> <br>for tap-prefixed packages<br> <li> Added <code>become: false</code> to the "Migrate old dinghy certificates" block to <br>prevent permission errors</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/371/files#diff-35e06808caf91480daa0d30bc6b6a1e4c425376bb5d3196d021dca2357bdd621">+45/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

