### PR TITLE
feat: add possibility to users to have their custom configuration for opencode

### DIFF
--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -747,16 +747,53 @@
             mode: "0755"
           become: no
 
-        - name: Deploy OpenCode configuration with security permissions and OpenCode provider disabled
-          copy:
+        - name: Check if opencode local override file exists
+          ansible.builtin.stat:
+            path: "{{ ansible_facts['env']['HOME'] }}/.config/opencode/opencode.local.json"
+          register: opencode_local_config_stat
+          become: no
+
+        - name: Read opencode base config
+          ansible.builtin.slurp:
+            src: "{{ dev_env_dir }}/config/macos/opencode.json"
+          register: opencode_base_config_content
+          no_log: true
+          become: no
+          when: opencode_local_config_stat.stat.exists
+
+        - name: Read opencode local override file
+          ansible.builtin.slurp:
+            src: "{{ ansible_facts['env']['HOME'] }}/.config/opencode/opencode.local.json"
+          register: opencode_local_config_content
+          no_log: true
+          become: no
+          when: opencode_local_config_stat.stat.exists
+
+        - name: Write merged opencode config with local overrides
+          ansible.builtin.copy:
+            content: "{{ (opencode_base_config_content.content | b64decode | from_json) | combine(opencode_local_config_content.content | b64decode | from_json, recursive=True) | to_nice_json }}\n"
+            dest: "{{ ansible_facts['env']['HOME'] }}/.config/opencode/opencode.json"
+            mode: "0644"
+          no_log: true
+          become: no
+          when: opencode_local_config_stat.stat.exists
+
+        - name: Copy opencode base config file (no local overrides)
+          ansible.builtin.copy:
             src: "{{ dev_env_dir }}/config/macos/opencode.json"
             dest: "{{ ansible_facts['env']['HOME'] }}/.config/opencode/opencode.json"
             mode: "0644"
           become: no
+          when: not opencode_local_config_stat.stat.exists
 
         - name: Display OpenCode configuration status
           debug:
-            msg: "✅ OpenCode configuration deployed successfully (OpenCode provider disabled; 175 permission rules — dangerous commands are blocked or require confirmation)"
+            msg: >-
+              {{ opencode_local_config_stat.stat.exists |
+                 ternary(
+                   '✅ OpenCode configuration deployed with local overrides merged (opencode.local.json)',
+                   '✅ OpenCode configuration deployed (OpenCode provider disabled; 175 permission rules — dangerous commands are blocked or require confirmation)'
+                 ) }}
 
         - name: Ensure zsh site-functions directory exists
           ansible.builtin.file:


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add support for custom local OpenCode configuration overrides

- Merge `opencode.local.json` with base config when it exists

- Update deployment status message to reflect override state


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Check opencode.local.json exists"] -- "exists" --> B["Read base config"]
  B -- "merge" --> C["Read local override config"]
  C -- "combine recursive" --> D["Write merged opencode.json"]
  A -- "not exists" --> E["Copy base config as-is"]
  D --> F["Display status with overrides message"]
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base.yml</strong><dd><code>Support merging local OpenCode config overrides</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ansible/macos/macos/base.yml

<ul><li>Added a stat check for <code>opencode.local.json</code> existence before deploying <br>config<br> <li> Added tasks to read and merge base config with local override using <br><code>combine(recursive=True)</code><br> <li> Added fallback task to copy base config when no local override exists<br> <li> Updated debug message to reflect whether local overrides were applied</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/379/files#diff-35e06808caf91480daa0d30bc6b6a1e4c425376bb5d3196d021dca2357bdd621">+40/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

