### PR TITLE
fix: remove readonly flag on GitHuman container and move reviews db

### DIFF
--- a/sjust/recipes/06-githuman.just
+++ b/sjust/recipes/06-githuman.just
@@ -5,6 +5,7 @@
 githuman_version := "0.6.0"
 githuman_label := "com.sparkfabrik.githuman"
 githuman_cache_volume := "githuman-npm-cache"
+githuman_data_volume := "githuman-data"
 
 # Start a GitHuman code review container for a project directory.
 [group('githuman')]
@@ -85,19 +86,32 @@ githuman-start $directory=".":
     echo "   Container: ${container_name}"
     echo "   FQDN: ${fqdn}"
 
+    # Ensure data volume subdirectory and home dir exist, owned by current user
+    docker run --rm \
+        -v {{githuman_data_volume}}:/data/githuman \
+        -v {{githuman_cache_volume}}:/cache/npm \
+        node:lts \
+        bash -c "mkdir -p /data/githuman/${container_name}/home && chown -R $(id -u):$(id -g) /data/githuman/${container_name} /cache/npm" \
+        > /dev/null
+
     docker run -d --rm \
         --name "${container_name}" \
+        --user "$(id -u):$(id -g)" \
+        -e HOME=/data/githuman/${container_name}/home \
         -e VIRTUAL_HOST="${fqdn}" \
         -e VIRTUAL_PORT=3847 \
-        -v "${target_dir}:/workspace:ro" \
-        -v {{githuman_cache_volume}}:/root/.npm \
-        -w /workspace \
+        -e GITHUMAN_DB_PATH="/data/githuman/${container_name}/home/reviews.db" \
+        -e npm_config_cache=/cache/npm \
+        -v "${target_dir}:${target_dir}" \
+        -v {{githuman_cache_volume}}:/cache/npm \
+        -v {{githuman_data_volume}}:/data/githuman \
+        -w "${target_dir}" \
         --label "{{githuman_label}}=true" \
         --label "{{githuman_label}}.directory=${target_dir}" \
         --label "{{githuman_label}}.fqdn=${fqdn}" \
         --label "{{githuman_label}}.token=${token}" \
         node:lts \
-        bash -c "git config --global --add safe.directory /workspace && npx githuman@{{githuman_version}} serve --host 0.0.0.0 --no-open --no-https --auth '${token}'" \
+        bash -c "git config --global --add safe.directory '${target_dir}' && npx githuman@{{githuman_version}} serve --host 0.0.0.0 --no-open --no-https --auth '${token}'" \
         > /dev/null
 
     echo "✅ GitHuman container started"
@@ -253,6 +267,11 @@ githuman-purge:
     if docker volume inspect {{githuman_cache_volume}} > /dev/null 2>&1; then
         docker volume rm {{githuman_cache_volume}} > /dev/null
         echo "✅ Removed npm cache volume ({{githuman_cache_volume}})"
+    fi
+
+    if docker volume inspect {{githuman_data_volume}} > /dev/null 2>&1; then
+        docker volume rm {{githuman_data_volume}} > /dev/null
+        echo "✅ Removed data volume ({{githuman_data_volume}})"
     fi
 
     echo "🧹 GitHuman purge complete"


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Remove read-only flag from workspace volume mount

- Add dedicated data volume for GitHuman reviews database

- Configure `GITHUMAN_DB_PATH` env var for persistent DB storage

- Update purge command to clean up new data volume


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["githuman-start"] -- "mounts workspace" --> B["workspace volume (rw)"]
  A -- "mounts cache" --> C["githuman-npm-cache volume"]
  A -- "mounts data" --> D["githuman-data volume"]
  D -- "stores" --> E["reviews.db per container"]
  F["githuman-purge"] -- "removes" --> C
  F -- "removes" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>06-githuman.just</strong><dd><code>Remove read-only workspace mount and add persistent data volume</code></dd></summary>
<hr>

sjust/recipes/06-githuman.just

<ul><li>Removed <code>:ro</code> (read-only) flag from workspace volume mount to allow <br>GitHuman to write <code>.githuman</code> folder<br> <li> Added new <code>githuman_data_volume</code> variable and corresponding Docker <br>volume for persistent reviews database<br> <li> Added <code>GITHUMAN_DB_PATH</code> environment variable pointing to a <br>per-container path inside the data volume<br> <li> Updated container startup command to create the DB directory before <br>launching GitHuman<br> <li> Updated <code>githuman-purge</code> recipe to also remove the new data volume</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/381/files#diff-7f5f478039ea5d5537778bc09ad06a1b34014b5f2b559b3dd918622cfb45d33e">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

