### PR TITLE
feat: improve GitHuman recipe with githuman-open and githuman-id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `sjust githuman-open` recipe to open the browser for a running GitHuman instance or start a new one
+- Added `sjust githuman-id` recipe to print the container ID of a running GitHuman instance
+
+### Changed
+
+- `githuman-start` now opens the browser automatically when a GitHuman instance is already running for the directory
 - Show upstream-available but not-yet-installed skills and agent profiles in `sf-agents-status` output, with `available / not installed` status and footer hint to run `sf-agents-refresh`
 - Added `sjust sf-openspec-configure` recipe to deploy OpenSpec custom profile with all 11 workflows and telemetry disabled, with interactive overwrite confirmation (pass `force` for programmatic/Ansible use)
 - Added Copilot CLI skill symlinks: creates per-skill symlinks in `~/.copilot/skills/` pointing to `~/.agents/skills/` so Copilot CLI can discover sparkdock-managed skills (workaround for [github/copilot-cli#1744](https://github.com/github/copilot-cli/issues/1744))

--- a/sjust/recipes/shared/02-githuman.just
+++ b/sjust/recipes/shared/02-githuman.just
@@ -34,9 +34,16 @@ githuman-start $directory=".":
     if [[ -n "${existing}" ]]; then
         while IFS='|' read -r dir name fqdn_existing token_existing; do
             if [[ "${dir}" == "${target_dir}" ]]; then
+                url="https://${fqdn_existing}?token=${token_existing}"
                 echo "⚠️  GitHuman is already running for ${target_dir}"
                 echo "   Container: ${name}"
-                echo "   URL: https://${fqdn_existing}?token=${token_existing}"
+                echo "   URL: ${url}"
+                echo "🌐 Opening ${url}"
+                if [[ "$(uname)" == "Darwin" ]]; then
+                    open "${url}"
+                else
+                    xdg-open "${url}"
+                fi
                 exit 0
             fi
         done <<< "${existing}"
@@ -154,6 +161,63 @@ githuman-start $directory=".":
     else
         xdg-open "${url}"
     fi
+
+# Open the browser for a running GitHuman instance, or start a new one.
+[group('githuman')]
+[no-cd]
+githuman-open $directory=".":
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if [[ ! -d "${directory}" ]]; then
+        echo "❌ Directory not found: ${directory}"
+        exit 1
+    fi
+
+    target_dir=$(cd "${directory}" && pwd)
+
+    match=$(docker ps --filter "label={{githuman_label}}=true" \
+        --format '{{ "{{" }}.Label "{{githuman_label}}.directory"{{ "}}" }}|{{ "{{" }}.Label "{{githuman_label}}.fqdn"{{ "}}" }}|{{ "{{" }}.Label "{{githuman_label}}.token"{{ "}}" }}' 2>/dev/null \
+        | grep "^${target_dir}|" || true)
+
+    if [[ -z "${match}" ]]; then
+        just githuman-start "${directory}"
+        exit 0
+    fi
+
+    IFS='|' read -r _dir fqdn token <<< "${match}"
+    url="https://${fqdn}?token=${token}"
+    echo "🌐 Opening ${url}"
+    if [[ "$(uname)" == "Darwin" ]]; then
+        open "${url}"
+    else
+        xdg-open "${url}"
+    fi
+
+# Print the container ID for a running GitHuman instance.
+[group('githuman')]
+[no-cd]
+githuman-id $directory=".":
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if [[ ! -d "${directory}" ]]; then
+        echo "❌ Directory not found: ${directory}"
+        exit 1
+    fi
+
+    target_dir=$(cd "${directory}" && pwd)
+
+    container_id=$(docker ps --filter "label={{githuman_label}}=true" \
+        --format '{{ "{{" }}.Label "{{githuman_label}}.directory"{{ "}}" }}|{{ "{{" }}.ID{{ "}}" }}' 2>/dev/null \
+        | grep "^${target_dir}|" | cut -d'|' -f2 || true)
+
+    if [[ -z "${container_id}" ]]; then
+        echo "No GitHuman instance running for this directory. Use 'githuman-start' to start one."
+        exit 1
+    fi
+
+    echo "${container_id}"
 
 # List all running GitHuman instances.
 [group('githuman')]


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added `githuman-open` recipe to open browser for running instance or start new one

- Added `githuman-id` recipe to print container ID of running GitHuman instance

- `githuman-start` now auto-opens browser when instance already running for directory

- Updated CHANGELOG with new recipes and behavior changes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["githuman-start"] -- "instance already running" --> B["Auto-open browser URL"]
  C["githuman-open"] -- "instance running" --> B
  C -- "no instance found" --> A
  D["githuman-id"] -- "instance running" --> E["Print container ID"]
  D -- "no instance found" --> F["Exit with error"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document new githuman recipes and behavior changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added entry for new <code>githuman-open</code> recipe<br> <li> Added entry for new <code>githuman-id</code> recipe<br> <li> Added entry for <code>githuman-start</code> browser auto-open behavior change</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/392/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>02-githuman.just</strong><dd><code>Add githuman-open and githuman-id recipes with auto-open</code>&nbsp; </dd></summary>
<hr>

sjust/recipes/shared/02-githuman.just

<ul><li><code>githuman-start</code> now opens the browser automatically when a duplicate <br>instance is detected for the same directory<br> <li> Added <code>githuman-open</code> recipe that opens the browser for a running <br>instance or delegates to <code>githuman-start</code> if none found<br> <li> Added <code>githuman-id</code> recipe that prints the Docker container ID for a <br>running GitHuman instance, with error handling for missing instances</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/392/files#diff-be6e4e42f559bb77f81e77b669d499302558df73d36d6fb53cfec810ef6f6828">+65/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

