### PR TITLE
feat: add DESCRIPTION column to agents-status table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,7 @@ All shell scripts must:
 - Include `set -euo pipefail` for error handling
 - Use `${variable}` syntax with braces (never bare `$variable`)
 - Use `local` for function variables to avoid namespace pollution
-- Pass shellcheck validation
+- Pass shellcheck validation (see below)
 - Prefer early-return / guard-clause style over `else` branches when checking pre-conditions:
 
 ```bash
@@ -128,6 +128,14 @@ if ! command -v cirrus >/dev/null 2>&1; then
 else
     echo "Cirrus CLI is already installed"
 fi
+```
+
+**Shellcheck Validation**
+
+Before committing changes to shell scripts, run shellcheck using the official Docker image:
+
+```bash
+docker run --rm -v "$(pwd):/src" koalaman/shellcheck:stable /src/bin/sparkdock-agents-status
 ```
 
 ## Python Standards
@@ -210,6 +218,9 @@ The sync script uses associative arrays to map each coding tool to its install d
 
 ### Manifest
 Located at `~/.cache/sparkdock/sf-skills-manifest.json`. V2 format with `skills` and `agents` top-level keys. V1 manifests upgrade organically (no migration code). Agent entries use composite keys like `the-architect/copilot`.
+
+### Catalog Metadata
+The upstream repo provides `config/catalog.json` with short human-friendly descriptions for each system skill and agent. The status script reads this file from the local cache (`~/.cache/sparkdock/agent-skills/config/catalog.json`) to display a DESCRIPTION column in the table. No sync changes are needed — the file is part of the cloned cache.
 
 ### sjust Recipes (`sjust/recipes/05-ai-coding-agents.just`)
 - `sf-agents-refresh [force]` — Sync all resources (skills + agents)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added DESCRIPTION column to `sjust sf-agents-status` tables, reading short descriptions from upstream `catalog.json` with tab-delimited rendering to support commas in descriptions
+- Added shellcheck Docker validation instructions to `AGENTS.md` for shell script quality checks before committing
 - Added Claude Code skill symlinks: creates per-skill symlinks in `~/.claude/skills/` pointing to `~/.agents/skills/` so Claude Code can discover sparkdock-managed skills (mirrors existing Copilot CLI support, uses shared tool registry for easy extensibility)
 - Added `sjust sf-copilot-premium-usage` recipe to show premium Copilot request usage in a formatted dashboard
 - Added `--json` option to `sjust sf-copilot-premium-usage` for raw API output

--- a/bin/sparkdock-agents-status
+++ b/bin/sparkdock-agents-status
@@ -20,6 +20,10 @@ MANIFEST_PATH="${HOME}/.cache/sparkdock/sf-skills-manifest.json"
 CACHE_DIR="${HOME}/.cache/sparkdock/agent-skills"
 SYSTEM_SKILLS_SUBDIR="skills/system"
 SYSTEM_AGENTS_SUBDIR="agents/system"
+CATALOG_PATH="${CACHE_DIR}/config/catalog.json"
+
+# Delimiter for table data (tab avoids conflicts with commas in descriptions)
+SEP=$'\t'
 
 # Tool registry (must mirror sparkdock-agents-sync)
 declare -A AGENT_TOOL_INSTALL_DIR=(
@@ -74,6 +78,32 @@ try:
 except Exception:
     print('')
 " "${MANIFEST_PATH}" "${section}" "${key}" 2>/dev/null || echo ""
+}
+
+# Get short description from catalog.json for a given section and name.
+# Truncates to max_len characters with ellipsis if needed.
+get_catalog_description() {
+    local section="$1"
+    local name="$2"
+    local max_len="${3:-60}"
+    if [[ ! -f "${CATALOG_PATH}" ]]; then
+        echo ""
+        return
+    fi
+    python3 -c "
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        data = json.load(f)
+    desc = data.get(sys.argv[2], {}).get(sys.argv[3], {}).get('description', '')
+    desc = ' '.join(desc.split())
+    max_len = int(sys.argv[4])
+    if len(desc) > max_len:
+        desc = desc[:max_len - 1] + '\u2026'
+    print(desc)
+except Exception:
+    print('')
+" "${CATALOG_PATH}" "${section}" "${name}" "${max_len}" 2>/dev/null || echo ""
 }
 
 # Check if an upstream resource exists at the given path.
@@ -135,7 +165,7 @@ print_faint() {
     fi
 }
 
-# Render a CSV table using gum table (with fallback to column).
+# Render a tab-delimited table using gum table (with fallback to column).
 # Workaround: gum v0.17.0 has a bug (charmbracelet/gum#833) where --print mode
 # applies bold styling to the first data row (selected-row state leaks).
 # We strip bold escape sequences (\e[1m) via perl to neutralise this.
@@ -146,6 +176,7 @@ render_table() {
     local csv_data="$1"
     if [[ "${HAS_GUM}" = true ]]; then
         echo "${csv_data}" | gum table --print \
+            --separator=$'\t' \
             --border.foreground 240 \
             | perl -pe '
                 s/\e\[1m//g;
@@ -158,7 +189,7 @@ render_table() {
                 s/\bok\b/\e[38;5;40mok\e[0m/g;
             '
     else
-        echo "${csv_data}" | column -t -s ','
+        echo "${csv_data}" | column -t -s $'\t'
     fi
 }
 
@@ -190,11 +221,11 @@ managed_skills="$(get_managed_names "skills")"
 # Build CSV header dynamically from tool registry (sorted for stable column order)
 sorted_tool_ids=()
 mapfile -t sorted_tool_ids < <(printf '%s\n' "${!TOOL_SKILLS_DIR[@]}" | sort)
-skills_csv="NAME,TYPE,STATUS"
+skills_csv="NAME${SEP}TYPE${SEP}STATUS${SEP}DESCRIPTION"
 empty_tool_cols=""
 for _tid in "${sorted_tool_ids[@]}"; do
-    skills_csv+=",$(echo "${_tid}" | tr '[:lower:]' '[:upper:]')"
-    empty_tool_cols+=","
+    skills_csv+="${SEP}$(echo "${_tid}" | tr '[:lower:]' '[:upper:]')"
+    empty_tool_cols+="${SEP}"
 done
 
 skills_found=false
@@ -208,7 +239,7 @@ if [[ -d "${SKILLS_DIR}" ]]; then
         seen_skills["${skill_name}"]=1
 
         if [[ ! -f "${skill_dir}/SKILL.md" ]]; then
-            skills_csv+=$'\n'"${skill_name},incomplete,no SKILL.md${empty_tool_cols}"
+            skills_csv+=$'\n'"${skill_name}${SEP}incomplete${SEP}no SKILL.md${SEP}${empty_tool_cols}"
             continue
         fi
 
@@ -217,19 +248,20 @@ if [[ -d "${SKILLS_DIR}" ]]; then
             availability_cols=""
             for _tid in "${sorted_tool_ids[@]}"; do
                 check_tool_availability "${_tid}" "${skill_name}"
-                availability_cols+=",${TOOL_AVAILABLE}"
+                availability_cols+="${SEP}${TOOL_AVAILABLE}"
             done
 
             upstream_file="${CACHE_DIR}/${SYSTEM_SKILLS_SUBDIR}/${skill_name}/SKILL.md"
             [[ "${CACHE_AVAILABLE}" != "true" || ! -f "${upstream_file}" ]] && upstream_file=""
             status=$(resolve_managed_status "skills" "${skill_name}" "${skill_dir}/SKILL.md" "${upstream_file}")
             [[ "${status}" == "update available" ]] && UPDATES_AVAILABLE=true
-            skills_csv+=$'\n'"${skill_name},managed,${status}${availability_cols}"
+            skill_desc=$(get_catalog_description "skills" "${skill_name}")
+            skills_csv+=$'\n'"${skill_name}${SEP}managed${SEP}${status}${SEP}${skill_desc}${availability_cols}"
         else
             if has_upstream_conflict "${CACHE_DIR}/${SYSTEM_SKILLS_SUBDIR}/${skill_name}/SKILL.md"; then
-                skills_csv+=$'\n'"${skill_name},user,conflicts with upstream${empty_tool_cols}"
+                skills_csv+=$'\n'"${skill_name}${SEP}user${SEP}conflicts with upstream${SEP}${empty_tool_cols}"
             else
-                skills_csv+=$'\n'"${skill_name},user,${empty_tool_cols}"
+                skills_csv+=$'\n'"${skill_name}${SEP}user${SEP}${SEP}${empty_tool_cols}"
             fi
         fi
     done
@@ -247,7 +279,8 @@ if [[ "${CACHE_AVAILABLE}" == "true" ]]; then
             [[ -n "${seen_skills[${skill_name}]+_}" ]] && continue
             skills_found=true
             NEW_RESOURCES_AVAILABLE=true
-            skills_csv+=$'\n'"${skill_name},available,not installed${empty_tool_cols}"
+            new_skill_desc=$(get_catalog_description "skills" "${skill_name}")
+            skills_csv+=$'\n'"${skill_name}${SEP}available${SEP}not installed${SEP}${new_skill_desc}${empty_tool_cols}"
         done
     fi
 fi
@@ -263,7 +296,7 @@ fi
 
 echo ""
 managed_agents="$(get_managed_names "agents")"
-agents_csv="NAME,TOOL,TYPE,STATUS"
+agents_csv="NAME${SEP}TOOL${SEP}TYPE${SEP}STATUS${SEP}DESCRIPTION"
 agents_found=false
 declare -A seen_agents=()
 
@@ -295,12 +328,13 @@ for tool_name in $(printf '%s\n' "${!AGENT_TOOL_INSTALL_DIR[@]}" | sort); do
             fi
             status=$(resolve_managed_status "agents" "${manifest_key}" "${agent_file}" "${upstream_file}")
             [[ "${status}" == "update available" ]] && UPDATES_AVAILABLE=true
-            agents_csv+=$'\n'"${agent_name},${tool_name},managed,${status}"
+            agent_desc=$(get_catalog_description "agents" "${agent_name}")
+            agents_csv+=$'\n'"${agent_name}${SEP}${tool_name}${SEP}managed${SEP}${status}${SEP}${agent_desc}"
         else
             if has_upstream_conflict "${CACHE_DIR}/${SYSTEM_AGENTS_SUBDIR}/${agent_name}/${tool_name}"; then
-                agents_csv+=$'\n'"${agent_name},${tool_name},user,conflicts with upstream"
+                agents_csv+=$'\n'"${agent_name}${SEP}${tool_name}${SEP}user${SEP}conflicts with upstream${SEP}"
             else
-                agents_csv+=$'\n'"${agent_name},${tool_name},user,"
+                agents_csv+=$'\n'"${agent_name}${SEP}${tool_name}${SEP}user${SEP}${SEP}"
             fi
         fi
     done
@@ -325,7 +359,8 @@ if [[ "${CACHE_AVAILABLE}" == "true" ]]; then
                 [[ -n "${seen_agents[${manifest_key}]+_}" ]] && continue
                 agents_found=true
                 NEW_RESOURCES_AVAILABLE=true
-                agents_csv+=$'\n'"${agent_name},${tool_name},available,not installed"
+                new_agent_desc=$(get_catalog_description "agents" "${agent_name}")
+                agents_csv+=$'\n'"${agent_name}${SEP}${tool_name}${SEP}available${SEP}not installed${SEP}${new_agent_desc}"
             done
         done
     fi


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

- Add a **DESCRIPTION** column to both skills and agent profiles tables in `sjust sf-agents-status`, reading short descriptions from upstream `catalog.json` (shipped via sf-awesome-copilot#44)
- Switch table delimiter from comma to **tab** so descriptions containing commas (e.g. "GitLab CLI (issues, MRs, pipelines, repos)") render correctly in both `gum table` and `column` fallback
- Add **shellcheck Docker validation** instructions to `AGENTS.md`
- Document **catalog metadata** in the AI Coding Agents System section of `AGENTS.md`

## Changes

### `bin/sparkdock-agents-status`
- New `CATALOG_PATH` variable pointing to cached `catalog.json`
- New `SEP` variable (`$'\t'`) used as delimiter throughout (replaces commas)
- New `get_catalog_description()` helper: reads catalog.json via python3, normalizes whitespace, truncates at 60 chars (matching `catalog.schema.json` maxLength)
- `render_table()`: uses `gum table --separator=$'\t'` and `column -t -s $'\t'` fallback
- DESCRIPTION column added to all row types in both skills and agents tables (managed, user, incomplete, not installed)
- Graceful degradation: empty descriptions when catalog.json is missing or a resource has no entry

### `AGENTS.md`
- Added shellcheck Docker validation section under Shell Script Standards
- Added Catalog Metadata section under AI Coding Agents System

## Testing

Tested locally with `SPARKDOCK_SKIP_FETCH=true` — both gum table and column fallback render correctly. Shellcheck passes (only expected SC1091 info about sourced files).

Closes #419


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Add DESCRIPTION column to both skills and agents tables in `sparkdock-agents-status`

- New `get_catalog_description()` helper reads from upstream `catalog.json` cache

- Switch table delimiter from comma to tab (`SEP=$'\t'`) to support commas in descriptions

- Document shellcheck Docker validation and catalog metadata in `AGENTS.md`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  catalog["catalog.json\n(~/.cache/sparkdock/agent-skills/config/catalog.json)"]
  helper["get_catalog_description()\n(python3 helper)"]
  skills["Skills Table\nNAME | TYPE | STATUS | DESCRIPTION | ..."]
  agents["Agents Table\nNAME | TOOL | TYPE | STATUS | DESCRIPTION"]
  sep["SEP=$'\\t'\n(tab delimiter)"]
  render["render_table()\ngum table --separator=$'\\t'"]

  catalog -- "read description" --> helper
  helper -- "skill desc" --> skills
  helper -- "agent desc" --> agents
  sep -- "used in" --> skills
  sep -- "used in" --> agents
  skills -- "render" --> render
  agents -- "render" --> render
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sparkdock-agents-status</strong><dd><code>Add DESCRIPTION column and tab delimiter to agents-status tables</code></dd></summary>
<hr>

bin/sparkdock-agents-status

<ul><li>Add <code>CATALOG_PATH</code> variable pointing to cached <code>catalog.json</code><br> <li> Add <code>SEP=$'\t'</code> tab delimiter variable, replacing all comma separators <br>throughout<br> <li> Add <code>get_catalog_description()</code> helper using python3 to read <br>descriptions from catalog.json with 60-char truncation and graceful <br>degradation<br> <li> Add DESCRIPTION column to skills and agents CSV headers and all row <br>types (managed, user, available, incomplete)<br> <li> Update <code>render_table()</code> to pass <code>--separator=$'\t'</code> to <code>gum table</code> and use <br><code>column -t -s $'\t'</code> as fallback</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/420/files#diff-892705812183d1227f4f4c4df5e2f0a5b3b3d2ef1c7978d57223d2b4c85787ab">+51/-16</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AGENTS.md</strong><dd><code>Document shellcheck validation and catalog metadata in AGENTS.md</code></dd></summary>
<hr>

AGENTS.md

<ul><li>Update shellcheck bullet to reference new "see below" section<br> <li> Add Shellcheck Validation section with Docker-based shellcheck command <br>example<br> <li> Add Catalog Metadata section documenting <code>config/catalog.json</code> and its <br>use in the status script</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/420/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+12/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

