### PR TITLE
fix(sjust): sjust autocomplete working again with just 1.50+

### DIFF
--- a/.github/workflows/test-sjust.yml
+++ b/.github/workflows/test-sjust.yml
@@ -81,13 +81,21 @@ jobs:
           if [ -f "$COMPLETION_FILE" ]; then
             echo "✅ Completion file created at: $COMPLETION_FILE"
             echo "Checking completion file content..."
-            head -5 "$COMPLETION_FILE"
+            cat "$COMPLETION_FILE"
 
-            # Verify it contains sjust references instead of just
-            if grep -q "sjust" "$COMPLETION_FILE"; then
-              echo "✅ Completion file correctly references 'sjust'"
+            # Verify compdef targets sjust
+            if head -1 "$COMPLETION_FILE" | grep -q '#compdef sjust'; then
+              echo "✅ Completion file has correct #compdef sjust header"
             else
-              echo "❌ Completion file does not contain 'sjust' references"
+              echo "❌ Completion file missing #compdef sjust header"
+              exit 1
+            fi
+
+            # Verify it uses just's dynamic completer (not a renamed sjust variant)
+            if grep -q '_clap_dynamic_completer_just' "$COMPLETION_FILE"; then
+              echo "✅ Completion file correctly calls _clap_dynamic_completer_just"
+            else
+              echo "❌ Completion file does not call _clap_dynamic_completer_just"
               exit 1
             fi
           else

--- a/.github/workflows/test-sjust.yml
+++ b/.github/workflows/test-sjust.yml
@@ -91,11 +91,19 @@ jobs:
               exit 1
             fi
 
-            # Verify it uses just's dynamic completer (not a renamed sjust variant)
-            if grep -q '_clap_dynamic_completer_just' "$COMPLETION_FILE"; then
-              echo "✅ Completion file correctly calls _clap_dynamic_completer_just"
+            # Verify it defines an _sjust function with scoped JUST_JUSTFILE
+            if grep -q '_sjust()' "$COMPLETION_FILE"; then
+              echo "✅ Completion file defines _sjust() function"
             else
-              echo "❌ Completion file does not call _clap_dynamic_completer_just"
+              echo "❌ Completion file does not define _sjust() function"
+              exit 1
+            fi
+
+            # Verify JUST_JUSTFILE is scoped to the subprocess (not exported globally)
+            if grep -q 'JUST_JUSTFILE="/opt/sparkdock/sjust/Justfile"' "$COMPLETION_FILE" && ! grep -q 'export JUST_JUSTFILE' "$COMPLETION_FILE"; then
+              echo "✅ JUST_JUSTFILE is correctly scoped to subprocess"
+            else
+              echo "❌ JUST_JUSTFILE should be scoped, not exported"
               exit 1
             fi
           else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed sjust zsh tab-completion (`_clap_dynamic_completer_sjust` not found) caused by just 1.40+ switching to dynamic clap completions — replaced sed-based renaming with a custom completion file that correctly bridges sjust to just's dynamic completer
 - Fixed Slack notification announcing already-released features by using zero-context git diff (`-U0`) to eliminate context lines that confused Claude AI
 - Fixed zsh completions from `~/.local/share/zsh/site-functions` not being discovered when the user's `.zshrc` calls `compinit` before sourcing sparkdock
 - Fixed menubar terminal commands (sjust, sparkdock, brew upgrade) closing immediately after completion by dropping into an interactive shell session

--- a/Makefile
+++ b/Makefile
@@ -40,41 +40,11 @@ endif
 	@# Copy sjust executable
 	sudo cp sjust/sjust.sh /usr/local/bin/sjust
 	sudo chmod 755 /usr/local/bin/sjust
-	@# Generate zsh completion
-	@echo "Generating zsh completion for sjust..."
+	@# Install zsh completion
+	@echo "Installing zsh completion for sjust..."
 	@BREW_PREFIX=$$(brew --prefix 2>/dev/null || echo "/usr/local"); \
 	sudo mkdir -p "$$BREW_PREFIX/share/zsh/site-functions"; \
-	printf '%s\n' \
-		'#compdef sjust' \
-		'' \
-		'# Zsh completion for sjust — a just wrapper with a fixed justfile.' \
-		'# Calls just directly with JUST_JUSTFILE scoped to the subprocess, filtering' \
-		"# out just's own flags (--*) so that only recipes are completed." \
-		'_sjust() {' \
-		'  local _CLAP_COMPLETE_INDEX=$$(expr $$CURRENT - 1)' \
-		"  local _CLAP_IFS=$$'\\n'" \
-		'' \
-		'  local completions=("$${(@f)$$(' \
-		'    _CLAP_IFS="$$_CLAP_IFS" \' \
-		'    _CLAP_COMPLETE_INDEX="$$_CLAP_COMPLETE_INDEX" \' \
-		'    JUST_COMPLETE="zsh" \' \
-		'    JUST_JUSTFILE="/opt/sparkdock/sjust/Justfile" \' \
-		'    just -- "$${words[@]}" 2>/dev/null \' \
-		"    | grep -v '^--'" \
-		'  )}")' \
-		'' \
-		'  if [[ -n $$completions ]]; then' \
-		'    local -a other=()' \
-		'    local completion' \
-		'    for completion in $$completions; do' \
-		'      other+=("$$completion")' \
-		'    done' \
-		'    [[ -n $$other ]] && _describe '"'"'recipes'"'"' other' \
-		'  fi' \
-		'}' \
-		'' \
-		'_sjust "$$@"' \
-	| sudo tee "$$BREW_PREFIX/share/zsh/site-functions/_sjust" > /dev/null; \
+	sudo cp sjust/completions/_sjust "$$BREW_PREFIX/share/zsh/site-functions/_sjust"; \
 	sudo chown $$(id -u):$$(id -g) "$$BREW_PREFIX/share/zsh/site-functions/_sjust"; \
 	sudo chmod 644 "$$BREW_PREFIX/share/zsh/site-functions/_sjust"
 	@echo "✅ sjust installed successfully!"

--- a/Makefile
+++ b/Makefile
@@ -44,11 +44,18 @@ endif
 	@echo "Generating zsh completion for sjust..."
 	@BREW_PREFIX=$$(brew --prefix 2>/dev/null || echo "/usr/local"); \
 	sudo mkdir -p "$$BREW_PREFIX/share/zsh/site-functions"; \
-	TEMP_FILE=$$(mktemp); \
-	just --completions zsh | sed -E 's/([\(_" ])just/\1sjust/g' > "$$TEMP_FILE"; \
-	sudo cp "$$TEMP_FILE" "$$BREW_PREFIX/share/zsh/site-functions/_sjust"; \
+	printf '%s\n' \
+		'#compdef sjust' \
+		'# Custom completion for sjust (sparkdock wrapper around just).' \
+		'# Uses just'\''s dynamic completer with the sparkdock justfile.' \
+		'export JUST_JUSTFILE="/opt/sparkdock/sjust/Justfile"' \
+		'source <(JUST_COMPLETE=zsh just)' \
+		'if [ "$$funcstack[1]" = "_sjust" ]; then' \
+		'  words[1]="just"' \
+		'  _clap_dynamic_completer_just "$$@"' \
+		'fi' \
+	| sudo tee "$$BREW_PREFIX/share/zsh/site-functions/_sjust" > /dev/null; \
 	sudo chown $$(id -u):$$(id -g) "$$BREW_PREFIX/share/zsh/site-functions/_sjust"; \
-	sudo chmod 644 "$$BREW_PREFIX/share/zsh/site-functions/_sjust"; \
-	rm -f "$$TEMP_FILE"
+	sudo chmod 644 "$$BREW_PREFIX/share/zsh/site-functions/_sjust"
 	@echo "✅ sjust installed successfully!"
 	@echo "You can now run: sjust http-proxy-install-update"

--- a/Makefile
+++ b/Makefile
@@ -46,14 +46,34 @@ endif
 	sudo mkdir -p "$$BREW_PREFIX/share/zsh/site-functions"; \
 	printf '%s\n' \
 		'#compdef sjust' \
-		'# Custom completion for sjust (sparkdock wrapper around just).' \
-		'# Uses just'\''s dynamic completer with the sparkdock justfile.' \
-		'export JUST_JUSTFILE="/opt/sparkdock/sjust/Justfile"' \
-		'source <(JUST_COMPLETE=zsh just)' \
-		'if [ "$$funcstack[1]" = "_sjust" ]; then' \
-		'  words[1]="just"' \
-		'  _clap_dynamic_completer_just "$$@"' \
-		'fi' \
+		'' \
+		'# Zsh completion for sjust — a just wrapper with a fixed justfile.' \
+		'# Calls just directly with JUST_JUSTFILE scoped to the subprocess, filtering' \
+		"# out just's own flags (--*) so that only recipes are completed." \
+		'_sjust() {' \
+		'  local _CLAP_COMPLETE_INDEX=$$(expr $$CURRENT - 1)' \
+		"  local _CLAP_IFS=$$'\\n'" \
+		'' \
+		'  local completions=("$${(@f)$$(' \
+		'    _CLAP_IFS="$$_CLAP_IFS" \' \
+		'    _CLAP_COMPLETE_INDEX="$$_CLAP_COMPLETE_INDEX" \' \
+		'    JUST_COMPLETE="zsh" \' \
+		'    JUST_JUSTFILE="/opt/sparkdock/sjust/Justfile" \' \
+		'    just -- "$${words[@]}" 2>/dev/null \' \
+		"    | grep -v '^--'" \
+		'  )}")' \
+		'' \
+		'  if [[ -n $$completions ]]; then' \
+		'    local -a other=()' \
+		'    local completion' \
+		'    for completion in $$completions; do' \
+		'      other+=("$$completion")' \
+		'    done' \
+		'    [[ -n $$other ]] && _describe '"'"'recipes'"'"' other' \
+		'  fi' \
+		'}' \
+		'' \
+		'_sjust "$$@"' \
 	| sudo tee "$$BREW_PREFIX/share/zsh/site-functions/_sjust" > /dev/null; \
 	sudo chown $$(id -u):$$(id -g) "$$BREW_PREFIX/share/zsh/site-functions/_sjust"; \
 	sudo chmod 644 "$$BREW_PREFIX/share/zsh/site-functions/_sjust"

--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -613,10 +613,19 @@
           ignore_errors: yes
 
         - name: Generate sjust zsh completion
-          shell: |
-            just --completions zsh | sed -E 's/([\(_" ])just/\1sjust/g' > "{{ brew_prefix.stdout }}/share/zsh/site-functions/_sjust"
-          register: completion_result
-          changed_when: completion_result.rc == 0
+          copy:
+            dest: "{{ brew_prefix.stdout }}/share/zsh/site-functions/_sjust"
+            content: |
+              #compdef sjust
+              # Custom completion for sjust (sparkdock wrapper around just).
+              # Uses just's dynamic completer with the sparkdock justfile.
+              export JUST_JUSTFILE="/opt/sparkdock/sjust/Justfile"
+              source <(JUST_COMPLETE=zsh just)
+              if [ "$funcstack[1]" = "_sjust" ]; then
+                words[1]="just"
+                _clap_dynamic_completer_just "$@"
+              fi
+            mode: "0644"
           become: no
 
         - name: Ensure sjust zsh completion has correct ownership and permissions

--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -617,14 +617,34 @@
             dest: "{{ brew_prefix.stdout }}/share/zsh/site-functions/_sjust"
             content: |
               #compdef sjust
-              # Custom completion for sjust (sparkdock wrapper around just).
-              # Uses just's dynamic completer with the sparkdock justfile.
-              export JUST_JUSTFILE="/opt/sparkdock/sjust/Justfile"
-              source <(JUST_COMPLETE=zsh just)
-              if [ "$funcstack[1]" = "_sjust" ]; then
-                words[1]="just"
-                _clap_dynamic_completer_just "$@"
-              fi
+
+              # Zsh completion for sjust — a just wrapper with a fixed justfile.
+              # Calls just directly with JUST_JUSTFILE scoped to the subprocess, filtering
+              # out just's own flags (--*) so that only recipes are completed.
+              _sjust() {
+                local _CLAP_COMPLETE_INDEX=$(expr $CURRENT - 1)
+                local _CLAP_IFS=$'\n'
+
+                local completions=("${(@f)$(
+                  _CLAP_IFS="$_CLAP_IFS" \
+                  _CLAP_COMPLETE_INDEX="$_CLAP_COMPLETE_INDEX" \
+                  JUST_COMPLETE="zsh" \
+                  JUST_JUSTFILE="/opt/sparkdock/sjust/Justfile" \
+                  just -- "${words[@]}" 2>/dev/null \
+                  | grep -v '^--'
+                )}")
+
+                if [[ -n $completions ]]; then
+                  local -a other=()
+                  local completion
+                  for completion in $completions; do
+                    other+=("$completion")
+                  done
+                  [[ -n $other ]] && _describe 'recipes' other
+                fi
+              }
+
+              _sjust "$@"
             mode: "0644"
           become: no
 

--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -612,39 +612,10 @@
           become_method: sudo
           ignore_errors: yes
 
-        - name: Generate sjust zsh completion
+        - name: Install sjust zsh completion
           copy:
+            src: "{{ dev_env_dir }}/sjust/completions/_sjust"
             dest: "{{ brew_prefix.stdout }}/share/zsh/site-functions/_sjust"
-            content: |
-              #compdef sjust
-
-              # Zsh completion for sjust — a just wrapper with a fixed justfile.
-              # Calls just directly with JUST_JUSTFILE scoped to the subprocess, filtering
-              # out just's own flags (--*) so that only recipes are completed.
-              _sjust() {
-                local _CLAP_COMPLETE_INDEX=$(expr $CURRENT - 1)
-                local _CLAP_IFS=$'\n'
-
-                local completions=("${(@f)$(
-                  _CLAP_IFS="$_CLAP_IFS" \
-                  _CLAP_COMPLETE_INDEX="$_CLAP_COMPLETE_INDEX" \
-                  JUST_COMPLETE="zsh" \
-                  JUST_JUSTFILE="/opt/sparkdock/sjust/Justfile" \
-                  just -- "${words[@]}" 2>/dev/null \
-                  | grep -v '^--'
-                )}")
-
-                if [[ -n $completions ]]; then
-                  local -a other=()
-                  local completion
-                  for completion in $completions; do
-                    other+=("$completion")
-                  done
-                  [[ -n $other ]] && _describe 'recipes' other
-                fi
-              }
-
-              _sjust "$@"
             mode: "0644"
           become: no
 

--- a/sjust/completions/_sjust
+++ b/sjust/completions/_sjust
@@ -1,0 +1,29 @@
+#compdef sjust
+
+# Zsh completion for sjust — a just wrapper with a fixed justfile.
+# Calls just directly with JUST_JUSTFILE scoped to the subprocess, filtering
+# out just's own flags (--*) so that only recipes are completed.
+_sjust() {
+    local _CLAP_COMPLETE_INDEX=$(expr $CURRENT - 1)
+    local _CLAP_IFS=$'\n'
+
+    local completions=("${(@f)$(
+        _CLAP_IFS="$_CLAP_IFS" \
+        _CLAP_COMPLETE_INDEX="$_CLAP_COMPLETE_INDEX" \
+        JUST_COMPLETE="zsh" \
+        JUST_JUSTFILE="/opt/sparkdock/sjust/Justfile" \
+        just -- "${words[@]}" 2>/dev/null \
+        | grep -v '^--'
+    )}")
+
+    if [[ -n $completions ]]; then
+        local -a other=()
+        local completion
+        for completion in $completions; do
+            other+=("$completion")
+        done
+        [[ -n $other ]] && _describe 'recipes' other
+    fi
+}
+
+_sjust "$@"


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix sjust zsh tab-completion broken by `just` 1.40+ dynamic clap completions

- Replace sed-based renaming with a custom completion file bridging sjust to just's dynamic completer

- Update Makefile and Ansible playbook to use new completion generation approach

- Improve CI test to verify correct `#compdef sjust` header and `_clap_dynamic_completer_just` usage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  old["Old approach: sed rename\n(just completions → sjust)"]
  new["New approach: custom completion file\n(_clap_dynamic_completer_just bridge)"]
  makefile["Makefile\n(install target)"]
  ansible["Ansible\nbase.yml"]
  ci["CI test\ntest-sjust.yml"]
  old -- "replaced by" --> new
  new -- "written by" --> makefile
  new -- "written by" --> ansible
  new -- "verified by" --> ci
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>Replace sed-based sjust completion with dynamic completer bridge</code></dd></summary>
<hr>

Makefile

<ul><li>Replaced <code>just --completions zsh | sed</code> renaming approach with a custom <br>static completion file<br> <li> New file sets <code>JUST_JUSTFILE</code>, sources just's dynamic completer, and <br>delegates to <code>_clap_dynamic_completer_just</code><br> <li> Removed temporary file usage; now uses <code>printf | sudo tee</code> directly</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/423/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+12/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>base.yml</strong><dd><code>Update Ansible sjust completion generation to use bridge file</code></dd></summary>
<hr>

ansible/macos/macos/base.yml

<ul><li>Replaced <code>shell</code> task running <code>just --completions zsh | sed</code> with an <br>Ansible <code>copy</code> task<br> <li> New completion file content bridges sjust to <br><code>_clap_dynamic_completer_just</code> with correct <code>JUST_JUSTFILE</code> export<br> <li> Removed <code>register</code>/<code>changed_when</code> from completion generation task</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/423/files#diff-35e06808caf91480daa0d30bc6b6a1e4c425376bb5d3196d021dca2357bdd621">+13/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test-sjust.yml</strong><dd><code>Improve CI verification of sjust completion file correctness</code></dd></summary>
<hr>

.github/workflows/test-sjust.yml

<ul><li>Changed <code>head -5</code> to <code>cat</code> to show full completion file content in CI logs<br> <li> Updated verification to check for <code>#compdef sjust</code> header instead of <br>generic <code>sjust</code> string<br> <li> Added additional check to verify <code>_clap_dynamic_completer_just</code> is <br>called in the completion file<br> <li> Added <code>exit 1</code> on both failure conditions for stricter CI enforcement</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/423/files#diff-6778ce9799b981b37415145031aab5b35494f9f30f961d1bf744f6599882de21">+13/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document sjust autocomplete fix in changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added changelog entry describing the sjust zsh tab-completion fix<br> <li> Documents root cause (just 1.40+ dynamic clap completions) and <br>solution (custom bridge file)</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/423/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

