### PR TITLE
fix(auth): support multiple Copilot auth providers with fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Changed Copilot API auth to support multiple sources (gh CLI, OpenCode) with automatic fallback on 401/403, removing the hard dependency on OpenCode for `sf-copilot-premium-usage`, `sf-copilot-model-limits`, and `sf-copilot-model-list` recipes
 - Improved `copilot-models.mjs` plain-text table output with proper column alignment when `gum` is not available, use `premium` API field for model grouping, and use unique temp file names for `gum` table rendering
 - Updated Copilot shell aliases (`co`/`ico` family) to latest available models: gpt-5-mini, claude-sonnet-4.6, claude-opus-4.6, gpt-5.3-codex, gemini-3.1-pro-preview
 - Moved `copilot-models.mjs` from `config/macos/scripts/` to `sjust/scripts/` to colocate with recipes

--- a/sjust/recipes/shared/01-ai-coding-agents.just
+++ b/sjust/recipes/shared/01-ai-coding-agents.just
@@ -19,19 +19,13 @@ sf-agents-status:
 
 # Check Copilot model context/output limits against the current opencode.json config.
 # Pass --update to automatically write the correct limits to opencode.json.
-# Warns if any values are outdated. Requires opencode to be authenticated with GitHub Copilot.
+# Requires GitHub Copilot authentication (gh CLI or OpenCode).
 # Refs: https://github.com/anomalyco/models.dev/issues/1136
 #       https://github.com/anomalyco/opencode/issues/16129
 [group('ai-coding-agents')]
 sf-copilot-model-limits *args='':
     #!/usr/bin/env bash
     set -euo pipefail
-    AUTH_FILE="${HOME}/.local/share/opencode/auth.json"
-    if [[ ! -f "${AUTH_FILE}" ]]; then
-        echo "ERROR: opencode auth not found at ${AUTH_FILE}"
-        echo "Run opencode and authenticate with GitHub Copilot first."
-        exit 1
-    fi
     if ! command -v node >/dev/null 2>&1; then
         echo "ERROR: Node.js is required but not found."
         exit 1
@@ -39,17 +33,11 @@ sf-copilot-model-limits *args='':
     node "{{sparkdock_path}}/sjust/scripts/copilot-models.mjs" {{args}}
 
 # List available Copilot model IDs (one per line). Useful for scripting with machine names.
-# Requires opencode to be authenticated with GitHub Copilot.
+# Requires GitHub Copilot authentication (gh CLI or OpenCode).
 [group('ai-coding-agents')]
 sf-copilot-model-list:
     #!/usr/bin/env bash
     set -euo pipefail
-    AUTH_FILE="${HOME}/.local/share/opencode/auth.json"
-    if [[ ! -f "${AUTH_FILE}" ]]; then
-        echo "ERROR: opencode auth not found at ${AUTH_FILE}"
-        echo "Run opencode and authenticate with GitHub Copilot first."
-        exit 1
-    fi
     if ! command -v node >/dev/null 2>&1; then
         echo "ERROR: Node.js is required but not found."
         exit 1
@@ -58,17 +46,11 @@ sf-copilot-model-list:
 
 # Show current personal GitHub Copilot premium request usage.
 # Pass --json to output the raw API response for scripting.
-# Requires opencode to be authenticated with GitHub Copilot.
+# Requires GitHub Copilot authentication (gh CLI or OpenCode).
 [group('ai-coding-agents')]
 sf-copilot-premium-usage *args='':
     #!/usr/bin/env bash
     set -euo pipefail
-    AUTH_FILE="${HOME}/.local/share/opencode/auth.json"
-    if [[ ! -f "${AUTH_FILE}" ]]; then
-        echo "ERROR: opencode auth not found at ${AUTH_FILE}"
-        echo "Run opencode and authenticate with GitHub Copilot first."
-        exit 1
-    fi
     if ! command -v node >/dev/null 2>&1; then
         echo "ERROR: Node.js is required but not found."
         exit 1

--- a/sjust/scripts/copilot-models.mjs
+++ b/sjust/scripts/copilot-models.mjs
@@ -12,7 +12,7 @@ import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import path, { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { fail, getAccessToken, BASE_HEADERS } from "./lib/copilot-auth.mjs";
+import { fail, fetchWithAuth, BASE_HEADERS } from "./lib/copilot-auth.mjs";
 import { printTable } from "./lib/gum.mjs";
 
 const OPENCODE_JSON_PATH = path.join(
@@ -54,9 +54,9 @@ function inferContext(limits) {
 // Data fetching
 // ---------------------------------------------------------------------------
 
-async function fetchModels(accessToken) {
-  const headers = { ...BASE_HEADERS, Authorization: `Bearer ${accessToken}` };
-  const response = await fetch(`${API_BASE}/models`, { headers });
+async function fetchModels() {
+  const headers = { ...BASE_HEADERS };
+  const response = await fetchWithAuth(`${API_BASE}/models`, headers, "Bearer");
   if (!response.ok) {
     const body = await response.text();
     fail(
@@ -313,8 +313,7 @@ function printSnippet(modelsBlock) {
 async function main() {
   const doUpdate = process.argv.includes("--update");
   const doList = process.argv.includes("--list");
-  const accessToken = await getAccessToken();
-  const payload = await fetchModels(accessToken);
+  const payload = await fetchModels();
   const apiModels = buildApiModels(payload);
 
   if (doList) {

--- a/sjust/scripts/copilot-usage.mjs
+++ b/sjust/scripts/copilot-usage.mjs
@@ -7,7 +7,7 @@
 //   node copilot-usage.mjs          # formatted dashboard
 //   node copilot-usage.mjs --json   # raw API JSON
 
-import { fail, getAccessToken, BASE_HEADERS } from "./lib/copilot-auth.mjs";
+import { fail, fetchWithAuth, BASE_HEADERS } from "./lib/copilot-auth.mjs";
 import { printBox } from "./lib/gum.mjs";
 
 const API_URL = "https://api.github.com/copilot_internal/user";
@@ -17,14 +17,13 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 // Data fetching
 // ---------------------------------------------------------------------------
 
-async function fetchUsage(accessToken) {
+async function fetchUsage() {
   const headers = {
     ...BASE_HEADERS,
     "Content-Type": "application/json",
     Accept: "application/json",
-    Authorization: `token ${accessToken}`,
   };
-  const response = await fetch(API_URL, { headers });
+  const response = await fetchWithAuth(API_URL, headers, "token");
   if (!response.ok) {
     const body = await response.text();
     fail(
@@ -160,8 +159,7 @@ function renderDashboard(data) {
 
 async function main() {
   const doJson = process.argv.includes("--json");
-  const accessToken = await getAccessToken();
-  const data = await fetchUsage(accessToken);
+  const data = await fetchUsage();
 
   if (doJson) {
     console.log(JSON.stringify(data, null, 2));

--- a/sjust/scripts/lib/copilot-auth.mjs
+++ b/sjust/scripts/lib/copilot-auth.mjs
@@ -153,7 +153,11 @@ export async function fetchWithAuth(url, headers, scheme = "Bearer") {
       return response;
     }
     // Drain the response body to allow connection reuse before trying the next token.
-    await response.text().catch(() => {});
+    await response.text().catch((err) => {
+      if (debug) {
+        console.error(`[copilot-auth] Error draining response body: ${err.message}`);
+      }
+    });
     if (debug) {
       console.error(
         `[copilot-auth] Token from "${source}" rejected (${response.status}), trying next`,

--- a/sjust/scripts/lib/copilot-auth.mjs
+++ b/sjust/scripts/lib/copilot-auth.mjs
@@ -129,13 +129,14 @@ export async function getAccessToken() {
 /**
  * Fetch a URL trying each available token in priority order.
  * Falls back to the next token on 401/403 responses.
- * Logs which auth source succeeded to stderr for debuggability.
+ * Set DEBUG=1 to log auth source activity to stderr.
  * @param {string} url
  * @param {Record<string, string>} headers - base headers (Authorization is added automatically)
  * @param {"token"|"Bearer"} scheme - Authorization scheme
  * @returns {Promise<Response>} the first successful response
  */
 export async function fetchWithAuth(url, headers, scheme = "Bearer") {
+  const debug = Boolean(process.env.DEBUG);
   const { tokens, warnings } = await resolveTokens();
   if (tokens.length === 0) {
     failNoAuth(warnings);
@@ -146,7 +147,17 @@ export async function fetchWithAuth(url, headers, scheme = "Bearer") {
       headers: { ...headers, Authorization: `${scheme} ${token}` },
     });
     if (response.status !== 401 && response.status !== 403) {
+      if (debug) {
+        console.error(`[copilot-auth] Token from "${source}" accepted`);
+      }
       return response;
+    }
+    // Drain the response body to allow connection reuse before trying the next token.
+    await response.text().catch(() => {});
+    if (debug) {
+      console.error(
+        `[copilot-auth] Token from "${source}" rejected (${response.status}), trying next`,
+      );
     }
     lastResponse = response;
   }

--- a/sjust/scripts/lib/copilot-auth.mjs
+++ b/sjust/scripts/lib/copilot-auth.mjs
@@ -1,10 +1,19 @@
 // Shared authentication and HTTP helpers for GitHub Copilot API scripts.
+//
+// Auth resolution order (first available wins):
+//   1. GitHub CLI (`gh auth token`)
+//   2. OpenCode (~/.local/share/opencode/auth.json)
+//
+// If a token is rejected by the API (401/403), the next provider is tried
+// automatically — so even if `gh` tokens don't work for a specific Copilot
+// endpoint, the chain falls through to the next available token.
 
 import { readFile } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
 import { homedir } from "node:os";
 import path from "node:path";
 
-export const AUTH_PATH = path.join(
+const OPENCODE_AUTH_PATH = path.join(
   homedir(),
   ".local/share/opencode/auth.json",
 );
@@ -22,22 +31,124 @@ export function fail(message) {
   process.exit(2);
 }
 
-export async function getAccessToken() {
+// ---------------------------------------------------------------------------
+// JSON helpers
+// ---------------------------------------------------------------------------
+
+async function readJsonFile(filePath, warnings) {
   let raw;
   try {
-    raw = await readFile(AUTH_PATH, "utf8");
-  } catch {
-    fail(
-      `Cannot read ${AUTH_PATH}\nMake sure opencode is installed and authenticated with GitHub Copilot.`,
-    );
+    raw = await readFile(filePath, "utf8");
+  } catch (err) {
+    if (err.code === "ENOENT") {
+      return null;
+    }
+    warnings.push(`Cannot read ${filePath}: ${err.message}`);
+    return null;
   }
-  let auth;
   try {
-    auth = JSON.parse(raw);
+    return JSON.parse(raw);
   } catch {
-    fail(`Invalid JSON in ${AUTH_PATH} — the auth file may be corrupted.`);
+    warnings.push(`Malformed JSON in ${filePath} — file may be corrupted`);
+    return null;
   }
-  const token = auth?.["github-copilot"]?.access;
-  if (!token) fail(`No github-copilot access token found in ${AUTH_PATH}`);
-  return token;
+}
+
+// ---------------------------------------------------------------------------
+// Auth providers (each returns a token string or null)
+// ---------------------------------------------------------------------------
+
+function getGhToken() {
+  try {
+    const token = execFileSync("gh", ["auth", "token"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    return token || null;
+  } catch {
+    return null;
+  }
+}
+
+async function getOpenCodeToken(warnings) {
+  const auth = await readJsonFile(OPENCODE_AUTH_PATH, warnings);
+  if (!auth) {
+    return null;
+  }
+  return auth?.["github-copilot"]?.access || null;
+}
+
+// ---------------------------------------------------------------------------
+// Provider chain
+// ---------------------------------------------------------------------------
+
+const providers = [
+  { name: "GitHub CLI (gh)", fn: getGhToken },
+  { name: "OpenCode", fn: getOpenCodeToken },
+];
+
+async function resolveTokens() {
+  const warnings = [];
+  const tokens = [];
+  for (const { name, fn } of providers) {
+    const token = await fn(warnings);
+    if (token) {
+      tokens.push({ token, source: name });
+    }
+  }
+  return { tokens, warnings };
+}
+
+function failNoAuth(warnings) {
+  const extra =
+    warnings.length > 0 ? "\n\nWarnings:\n  " + warnings.join("\n  ") : "";
+  fail(
+    "No Copilot authentication found.\n" +
+      "Authenticate with one of the following:\n" +
+      "  • GitHub CLI: run `gh auth login`\n" +
+      "  • OpenCode: run opencode and sign in with GitHub Copilot" +
+      extra,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the first available access token from the provider chain.
+ */
+export async function getAccessToken() {
+  const { tokens, warnings } = await resolveTokens();
+  if (tokens.length === 0) {
+    failNoAuth(warnings);
+  }
+  return tokens[0].token;
+}
+
+/**
+ * Fetch a URL trying each available token in priority order.
+ * Falls back to the next token on 401/403 responses.
+ * Logs which auth source succeeded to stderr for debuggability.
+ * @param {string} url
+ * @param {Record<string, string>} headers - base headers (Authorization is added automatically)
+ * @param {"token"|"Bearer"} scheme - Authorization scheme
+ * @returns {Promise<Response>} the first successful response
+ */
+export async function fetchWithAuth(url, headers, scheme = "Bearer") {
+  const { tokens, warnings } = await resolveTokens();
+  if (tokens.length === 0) {
+    failNoAuth(warnings);
+  }
+  let lastResponse;
+  for (const { token, source } of tokens) {
+    const response = await fetch(url, {
+      headers: { ...headers, Authorization: `${scheme} ${token}` },
+    });
+    if (response.status !== 401 && response.status !== 403) {
+      return response;
+    }
+    lastResponse = response;
+  }
+  return lastResponse;
 }


### PR DESCRIPTION
## Problem

Copilot API recipes (`sf-copilot-premium-usage`, `sf-copilot-model-limits`, `sf-copilot-model-list`) required OpenCode authentication exclusively. Users without OpenCode couldn't use these commands.

## Solution

Auth resolution now tries multiple providers in order:

| # | Provider | Source |
|---|----------|--------|
| 1 | GitHub CLI | `gh auth token` |
| 2 | OpenCode | `~/.local/share/opencode/auth.json` |

If a token is rejected (401/403), the next provider is tried automatically via the new `fetchWithAuth()` helper.

## Changes

- **`sjust/scripts/lib/copilot-auth.mjs`** — Rewritten with provider chain, `readJsonFile()` helper with warning collection, centralized `fetchWithAuth()` for token rotation on 401/403
- **`copilot-usage.mjs` / `copilot-models.mjs`** — Now use `fetchWithAuth()` instead of manual auth handling
- **`01-ai-coding-agents.just`** — Removed redundant bash-level `AUTH_FILE` checks from 3 recipes
- **`CHANGELOG.md`** — Entry under `### Changed`

## Testing

Verified locally: `node sjust/scripts/copilot-usage.mjs` works with `gh` auth when OpenCode is not installed.