### PR TITLE
feat(menubar): auto-refresh status after upgrade actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Menubar app now auto-refreshes subsystem status after upgrade actions complete so the icon updates immediately
 - Changed Copilot API auth to support multiple sources (gh CLI, OpenCode) with automatic fallback on 401/403, removing the hard dependency on OpenCode for `sf-copilot-premium-usage`, `sf-copilot-model-limits`, and `sf-copilot-model-list` recipes
 - Improved `copilot-models.mjs` plain-text table output with proper column alignment when `gum` is not available, use `premium` API field for model grouping, and use unique temp file names for `gum` table rendering
 - Updated Copilot shell aliases (`co`/`ico` family) to latest available models: gpt-5-mini, claude-sonnet-4.6, claude-opus-4.6, gpt-5.3-codex, gemini-3.1-pro-preview

--- a/src/menubar-app/Sources/SparkdockManager/main.swift
+++ b/src/menubar-app/Sources/SparkdockManager/main.swift
@@ -938,11 +938,24 @@ class SparkdockMenubarApp: NSObject, NSApplicationDelegate {
     }
 
 
+    /// Executes a command in a new Ghostty terminal window.
+    /// - Parameters:
+    ///   - command: The shell command to run. Current callers pass hardcoded strings only.
+    ///   - recheckNotification: Optional Darwin notification name to post after the command finishes.
+    ///     When set and notifyutil is available, a `notifyutil -p` call is appended so the app
+    ///     can recheck the relevant subsystem. No sanitization is performed on either parameter;
+    ///     callers must ensure values are safe for shell interpolation.
     private func executeTerminalCommand(_ command: String, recheckNotification: String? = nil) {
         // Append Darwin notification trigger if provided (fires after command completes)
         let finalCommand: String
         if let notification = recheckNotification {
-            finalCommand = "\(command); /usr/bin/notifyutil -p \(notification)"
+            let notifyutilPath = "/usr/bin/notifyutil"
+            if FileManager.default.fileExists(atPath: notifyutilPath) {
+                finalCommand = "\(command); \(notifyutilPath) -p \(notification)"
+            } else {
+                AppConstants.logger.warning("Skipping recheck notification '\(notification)' because \(notifyutilPath) is unavailable")
+                finalCommand = command
+            }
         } else {
             finalCommand = command
         }

--- a/src/menubar-app/Sources/SparkdockManager/main.swift
+++ b/src/menubar-app/Sources/SparkdockManager/main.swift
@@ -940,11 +940,13 @@ class SparkdockMenubarApp: NSObject, NSApplicationDelegate {
 
     /// Executes a command in a new Ghostty terminal window.
     /// - Parameters:
-    ///   - command: The shell command to run. Current callers pass hardcoded strings only.
+    ///   - command: The shell command to run. Callers include both hardcoded commands and
+    ///     commands loaded from dynamic menu configuration (for example, `menu.json`).
     ///   - recheckNotification: Optional Darwin notification name to post after the command finishes.
-    ///     When set and notifyutil is available, a `notifyutil -p` call is appended so the app
-    ///     can recheck the relevant subsystem. No sanitization is performed on either parameter;
-    ///     callers must ensure values are safe for shell interpolation.
+    ///     Current callers pass hardcoded notification names only. When set and notifyutil is
+    ///     available, a `notifyutil -p` call is appended so the app can recheck the relevant
+    ///     subsystem. No sanitization is performed on either parameter; callers must ensure
+    ///     values are safe for shell interpolation.
     private func executeTerminalCommand(_ command: String, recheckNotification: String? = nil) {
         // Append Darwin notification trigger if provided (fires after command completes)
         let finalCommand: String

--- a/src/menubar-app/Sources/SparkdockManager/main.swift
+++ b/src/menubar-app/Sources/SparkdockManager/main.swift
@@ -45,6 +45,16 @@ fileprivate struct MenuItem: Codable {
     }
 }
 
+// MARK: - Darwin Notification Names (for post-upgrade recheck)
+private enum RecheckNotification {
+    static let prefix = "com.sparkfabrik.sparkdock.recheck"
+    static let sparkdock = "\(prefix).sparkdock"
+    static let brew = "\(prefix).brew"
+    static let httpProxy = "\(prefix).http-proxy"
+    static let agents = "\(prefix).agents"
+    static let all = [sparkdock, brew, httpProxy, agents]
+}
+
 // MARK: - Menu Item Tags
 private enum MenuItemTag: Int {
     case updateNow = 1
@@ -99,6 +109,15 @@ private func withTimeout<T>(seconds: TimeInterval, operation: @escaping () async
     }
 }
 
+// MARK: - Darwin Notification Callback (C-compatible, must be top-level)
+private let darwinRecheckCallback: CFNotificationCallback = { _, observer, name, _, _ in
+    guard let observer = observer else { return }
+    let app = Unmanaged<SparkdockMenubarApp>.fromOpaque(observer).takeUnretainedValue()
+    guard let notificationName = name?.rawValue as String? else { return }
+    AppConstants.logger.info("Received Darwin recheck notification: \(notificationName)")
+    app.handleRecheckNotification(notificationName)
+}
+
 class SparkdockMenubarApp: NSObject, NSApplicationDelegate {
     var statusItem: NSStatusItem?
     var menu: NSMenu?
@@ -109,6 +128,8 @@ class SparkdockMenubarApp: NSObject, NSApplicationDelegate {
     var outdatedBrewFormulaeCount = 0
     var outdatedBrewCasksCount = 0
     var totalOutdatedBrewCount: Int { outdatedBrewFormulaeCount + outdatedBrewCasksCount }
+    /// Generation counter to discard stale full-check results after a per-subsystem recheck
+    private var checkGeneration: Int = 0
     var statusMenuItem: NSMenuItem?
     var sparkdockStatusMenuItem: NSMenuItem?
     var brewStatusMenuItem: NSMenuItem?
@@ -169,6 +190,7 @@ class SparkdockMenubarApp: NSObject, NSApplicationDelegate {
         loadMenuConfiguration()
         setupMenuBar()
         setupUpdateObservers()
+        setupRecheckObservers()
 
         // Set initial status and check for updates
         sparkdockStatusMenuItem?.attributedTitle = createStatusTitle("Checking for updates (Sparkdock)...", color: .systemYellow)
@@ -399,6 +421,10 @@ class SparkdockMenubarApp: NSObject, NSApplicationDelegate {
         NSWorkspace.shared.notificationCenter.removeObserver(self)
         pathMonitor?.cancel()
         pathMonitor = nil
+        CFNotificationCenterRemoveEveryObserver(
+            CFNotificationCenterGetDarwinNotifyCenter(),
+            Unmanaged.passUnretained(self).toOpaque()
+        )
         AppConstants.logger.info("Update observers cleaned up")
     }
     @objc private func systemDidWake() {
@@ -438,7 +464,100 @@ class SparkdockMenubarApp: NSObject, NSApplicationDelegate {
         checkForUpdates()
     }
 
+    // MARK: - Darwin Notification Observers (post-upgrade recheck)
+
+    private func setupRecheckObservers() {
+        let center = CFNotificationCenterGetDarwinNotifyCenter()
+        for name in RecheckNotification.all {
+            CFNotificationCenterAddObserver(
+                center,
+                Unmanaged.passUnretained(self).toOpaque(),
+                darwinRecheckCallback,
+                name as CFString,
+                nil,
+                .deliverImmediately
+            )
+        }
+        AppConstants.logger.info("Darwin recheck observers configured")
+    }
+
+    fileprivate func handleRecheckNotification(_ name: String) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            let handlers: [String: () -> Void] = [
+                RecheckNotification.sparkdock: self.recheckSparkdock,
+                RecheckNotification.brew: self.recheckBrew,
+                RecheckNotification.httpProxy: self.recheckHttpProxy,
+                RecheckNotification.agents: self.recheckAgents
+            ]
+            handlers[name]?()
+        }
+    }
+
+    private func recheckSparkdock() {
+        checkGeneration += 1
+        sparkdockStatusMenuItem?.attributedTitle = createStatusTitle("Checking for updates (Sparkdock)...", color: .systemYellow)
+        Task(priority: .background) {
+            let result = await runSparkdockCheck()
+            await MainActor.run {
+                self.hasUpdates = result
+                self.refreshUI()
+            }
+        }
+    }
+
+    private func recheckBrew() {
+        checkGeneration += 1
+        brewStatusMenuItem?.attributedTitle = createStatusTitle("Checking for updates (Brew)...", color: .systemYellow)
+        Task(priority: .background) {
+            let (formulaeCount, casksCount) = await runBrewOutdatedCheck()
+            await MainActor.run {
+                self.outdatedBrewFormulaeCount = formulaeCount
+                self.outdatedBrewCasksCount = casksCount
+                self.refreshUI()
+            }
+        }
+    }
+
+    private func recheckHttpProxy() {
+        checkGeneration += 1
+        httpProxyStatusMenuItem?.attributedTitle = createStatusTitle("Checking for updates (Http-proxy)...", color: .systemYellow)
+        Task(priority: .background) {
+            let result = await runHttpProxyCheck()
+            await MainActor.run {
+                self.hasHttpProxyUpdates = result
+                self.refreshUI()
+            }
+        }
+    }
+
+    private func recheckAgents() {
+        checkGeneration += 1
+        agentsStatusMenuItem?.attributedTitle = createStatusTitle("Checking for updates (Agent Skills)...", color: .systemYellow)
+        Task(priority: .background) {
+            let result = await runAgentsCheck()
+            await MainActor.run {
+                self.hasAgentUpdates = result
+                self.refreshUI()
+            }
+        }
+    }
+
+    /// Refresh UI using current instance state (safe for per-subsystem updates)
+    private func refreshUI() {
+        updateUI(
+            hasUpdates: hasUpdates,
+            outdatedBrewFormulae: outdatedBrewFormulaeCount,
+            outdatedBrewCasks: outdatedBrewCasksCount,
+            hasHttpProxyUpdates: hasHttpProxyUpdates,
+            hasAgentUpdates: hasAgentUpdates,
+            agentsConfigured: isAgentsConfigured()
+        )
+    }
+
     private func checkForUpdates() {
+        checkGeneration += 1
+        let expectedGeneration = checkGeneration
         Task(priority: .background) {
             let hasUpdates = await runSparkdockCheck()
             let (formulaeCount, casksCount) = await runBrewOutdatedCheck()
@@ -446,6 +565,11 @@ class SparkdockMenubarApp: NSObject, NSApplicationDelegate {
             let hasAgentUpdates = await runAgentsCheck()
             let agentsConfigured = isAgentsConfigured()
             await MainActor.run {
+                // Discard results if a per-subsystem recheck started after this full check
+                guard self.checkGeneration == expectedGeneration else {
+                    AppConstants.logger.info("Discarding stale full-check results (generation \(expectedGeneration) != \(self.checkGeneration))")
+                    return
+                }
                 updateUI(hasUpdates: hasUpdates, outdatedBrewFormulae: formulaeCount, outdatedBrewCasks: casksCount, hasHttpProxyUpdates: hasHttpProxyUpdates, hasAgentUpdates: hasAgentUpdates, agentsConfigured: agentsConfigured)
             }
         }
@@ -791,31 +915,38 @@ class SparkdockMenubarApp: NSObject, NSApplicationDelegate {
 
     @objc private func updateNow() {
         guard hasUpdates else { return }
-        executeTerminalCommand("sparkdock")
+        executeTerminalCommand("sparkdock", recheckNotification: RecheckNotification.sparkdock)
     }
 
     @objc private func upgradeBrew() {
         guard totalOutdatedBrewCount > 0 else { return }
-
         // Create a compound command that only runs the second upgrade if the first succeeds
         let upgradeCommand = "brew upgrade && brew upgrade --cask"
-        executeTerminalCommand(upgradeCommand)
+        executeTerminalCommand(upgradeCommand, recheckNotification: RecheckNotification.brew)
     }
 
     @objc private func upgradeHttpProxy() {
         guard hasHttpProxyUpdates else { return }
-        executeTerminalCommand("sjust http-proxy-install-update")
+        executeTerminalCommand("sjust http-proxy-install-update", recheckNotification: RecheckNotification.httpProxy)
     }
 
     @objc private func upgradeAgents() {
         // Allow refresh when agent resources have updates OR are not configured (initial setup)
         let agentsConfigured = isAgentsConfigured()
         guard hasAgentUpdates || !agentsConfigured else { return }
-        executeTerminalCommand("sjust sf-agents-refresh")
+        executeTerminalCommand("sjust sf-agents-refresh", recheckNotification: RecheckNotification.agents)
     }
 
 
-    private func executeTerminalCommand(_ command: String) {
+    private func executeTerminalCommand(_ command: String, recheckNotification: String? = nil) {
+        // Append Darwin notification trigger if provided (fires after command completes)
+        let finalCommand: String
+        if let notification = recheckNotification {
+            finalCommand = "\(command); /usr/bin/notifyutil -p \(notification)"
+        } else {
+            finalCommand = command
+        }
+
         let process = Process()
         // Use the ghostty CLI to open a new window with the command
         process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
@@ -828,13 +959,13 @@ class SparkdockMenubarApp: NSObject, NSApplicationDelegate {
             "--args",
             "--window-width=200",
             "--window-height=40",
-            "-e", "/bin/zsh", "-l", "-c", "\(command); exec zsh"
+            "-e", "/bin/zsh", "-l", "-c", "\(finalCommand); exec zsh"
         ]
         do {
             try process.run()
-            AppConstants.logger.info("Executed terminal command: \(command)")
+            AppConstants.logger.info("Executed terminal command: \(finalCommand)")
         } catch {
-            AppConstants.logger.error("Failed to execute terminal command '\(command)': \(error.localizedDescription)")
+            AppConstants.logger.error("Failed to execute terminal command '\(finalCommand)': \(error.localizedDescription)")
             showErrorAlert("Command Execution Error", "Failed to execute command: \(command)")
         }
     }

--- a/src/menubar-app/Tests/SparkdockManagerTests/SparkdockManagerTests.swift
+++ b/src/menubar-app/Tests/SparkdockManagerTests/SparkdockManagerTests.swift
@@ -103,4 +103,70 @@ final class SparkdockManagerTests: XCTestCase {
         let httpProxyCheckCommand = ["http-proxy-check-updates"]
         XCTAssertEqual(httpProxyCheckCommand.first, "http-proxy-check-updates", "Http-proxy check command should be correct")
     }
+
+    // MARK: - Darwin Recheck Notification Tests
+
+    func testRecheckNotificationNamesAreUnique() {
+        let names = [
+            "com.sparkfabrik.sparkdock.recheck.sparkdock",
+            "com.sparkfabrik.sparkdock.recheck.brew",
+            "com.sparkfabrik.sparkdock.recheck.http-proxy",
+            "com.sparkfabrik.sparkdock.recheck.agents"
+        ]
+        let uniqueNames = Set(names)
+        XCTAssertEqual(names.count, uniqueNames.count, "All recheck notification names should be unique")
+    }
+
+    func testRecheckNotificationNamesHaveCorrectPrefix() {
+        let prefix = "com.sparkfabrik.sparkdock.recheck."
+        let names = [
+            "com.sparkfabrik.sparkdock.recheck.sparkdock",
+            "com.sparkfabrik.sparkdock.recheck.brew",
+            "com.sparkfabrik.sparkdock.recheck.http-proxy",
+            "com.sparkfabrik.sparkdock.recheck.agents"
+        ]
+        for name in names {
+            XCTAssertTrue(name.hasPrefix(prefix), "Notification name '\(name)' should have prefix '\(prefix)'")
+        }
+    }
+
+    func testRecheckNotificationAllContainsAllSubsystems() {
+        let allNotifications = [
+            "com.sparkfabrik.sparkdock.recheck.sparkdock",
+            "com.sparkfabrik.sparkdock.recheck.brew",
+            "com.sparkfabrik.sparkdock.recheck.http-proxy",
+            "com.sparkfabrik.sparkdock.recheck.agents"
+        ]
+        XCTAssertEqual(allNotifications.count, 4, "Should have exactly 4 recheck notifications (one per subsystem)")
+    }
+
+    func testNotifyutilExists() {
+        let notifyutilPath = "/usr/bin/notifyutil"
+        let fileExists = FileManager.default.fileExists(atPath: notifyutilPath)
+        if fileExists {
+            XCTAssertTrue(fileExists, "notifyutil should exist at \(notifyutilPath) on macOS systems")
+        }
+    }
+
+    func testUpgradeCommandAppendsNotification() {
+        let command = "brew upgrade && brew upgrade --cask"
+        let notification = "com.sparkfabrik.sparkdock.recheck.brew"
+        let finalCommand = "\(command); /usr/bin/notifyutil -p \(notification)"
+        XCTAssertTrue(finalCommand.hasPrefix(command), "Final command should start with original command")
+        XCTAssertTrue(finalCommand.contains("; /usr/bin/notifyutil -p "), "Final command should contain notifyutil trigger")
+        XCTAssertTrue(finalCommand.hasSuffix(notification), "Final command should end with notification name")
+    }
+
+    func testUpgradeCommandWithoutNotification() {
+        let command = "some-dynamic-menu-command"
+        let recheckNotification: String? = nil
+        let finalCommand: String
+        if let notification = recheckNotification {
+            finalCommand = "\(command); /usr/bin/notifyutil -p \(notification)"
+        } else {
+            finalCommand = command
+        }
+        XCTAssertEqual(finalCommand, command, "Command without notification should remain unchanged")
+        XCTAssertFalse(finalCommand.contains("notifyutil"), "Command without notification should not contain notifyutil")
+    }
 }

--- a/src/menubar-app/Tests/SparkdockManagerTests/SparkdockManagerTests.swift
+++ b/src/menubar-app/Tests/SparkdockManagerTests/SparkdockManagerTests.swift
@@ -106,46 +106,35 @@ final class SparkdockManagerTests: XCTestCase {
 
     // MARK: - Darwin Recheck Notification Tests
 
+    /// Expected notification names — must match RecheckNotification constants in main.swift.
+    private static let expectedRecheckNotifications = [
+        "com.sparkfabrik.sparkdock.recheck.sparkdock",
+        "com.sparkfabrik.sparkdock.recheck.brew",
+        "com.sparkfabrik.sparkdock.recheck.http-proxy",
+        "com.sparkfabrik.sparkdock.recheck.agents"
+    ]
+
     func testRecheckNotificationNamesAreUnique() {
-        let names = [
-            "com.sparkfabrik.sparkdock.recheck.sparkdock",
-            "com.sparkfabrik.sparkdock.recheck.brew",
-            "com.sparkfabrik.sparkdock.recheck.http-proxy",
-            "com.sparkfabrik.sparkdock.recheck.agents"
-        ]
+        let names = Self.expectedRecheckNotifications
         let uniqueNames = Set(names)
         XCTAssertEqual(names.count, uniqueNames.count, "All recheck notification names should be unique")
     }
 
     func testRecheckNotificationNamesHaveCorrectPrefix() {
         let prefix = "com.sparkfabrik.sparkdock.recheck."
-        let names = [
-            "com.sparkfabrik.sparkdock.recheck.sparkdock",
-            "com.sparkfabrik.sparkdock.recheck.brew",
-            "com.sparkfabrik.sparkdock.recheck.http-proxy",
-            "com.sparkfabrik.sparkdock.recheck.agents"
-        ]
-        for name in names {
+        for name in Self.expectedRecheckNotifications {
             XCTAssertTrue(name.hasPrefix(prefix), "Notification name '\(name)' should have prefix '\(prefix)'")
         }
     }
 
     func testRecheckNotificationAllContainsAllSubsystems() {
-        let allNotifications = [
-            "com.sparkfabrik.sparkdock.recheck.sparkdock",
-            "com.sparkfabrik.sparkdock.recheck.brew",
-            "com.sparkfabrik.sparkdock.recheck.http-proxy",
-            "com.sparkfabrik.sparkdock.recheck.agents"
-        ]
-        XCTAssertEqual(allNotifications.count, 4, "Should have exactly 4 recheck notifications (one per subsystem)")
+        XCTAssertEqual(Self.expectedRecheckNotifications.count, 4, "Should have exactly 4 recheck notifications (one per subsystem)")
     }
 
     func testNotifyutilExists() {
         let notifyutilPath = "/usr/bin/notifyutil"
         let fileExists = FileManager.default.fileExists(atPath: notifyutilPath)
-        if fileExists {
-            XCTAssertTrue(fileExists, "notifyutil should exist at \(notifyutilPath) on macOS systems")
-        }
+        XCTAssertTrue(fileExists, "notifyutil should exist at \(notifyutilPath) on macOS systems")
     }
 
     func testUpgradeCommandAppendsNotification() {

--- a/src/menubar-app/Tests/SparkdockManagerTests/SparkdockManagerTests.swift
+++ b/src/menubar-app/Tests/SparkdockManagerTests/SparkdockManagerTests.swift
@@ -127,7 +127,7 @@ final class SparkdockManagerTests: XCTestCase {
         }
     }
 
-    func testRecheckNotificationAllContainsAllSubsystems() {
+    func testRecheckNotificationsHasOneEntryPerSubsystem() {
         XCTAssertEqual(Self.expectedRecheckNotifications.count, 4, "Should have exactly 4 recheck notifications (one per subsystem)")
     }
 


### PR DESCRIPTION
### **User description**
## Problem

After clicking an upgrade action in the menubar (Sparkdock, Brew, Http-proxy, Agent Skills), the status icon stays in its old state until the next system wake or network change event. Users have no immediate feedback that the upgrade completed successfully.

## Solution

Each upgrade command now appends a `notifyutil` call that fires a Darwin notification when the terminal command finishes. The menubar app listens for these notifications and triggers only the relevant subsystem recheck, updating the icon immediately.

A generation counter prevents stale full-check results from overwriting fresh per-subsystem rechecks.

## Changes

- **`main.swift`** — Darwin notification observers, per-subsystem recheck methods, generation counter, `notifyutil` trigger on the 4 upgrade commands
- **`SparkdockManagerTests.swift`** — 6 new tests: notification name uniqueness/prefix/count, `notifyutil` existence, command construction
- **`CHANGELOG.md`** — Entry under `### Changed`

## What is NOT changed

- Click-to-check behavior (status rows still trigger a full check)
- Wake/network-change triggers
- Dynamic menu items from JSON config

## Testing

Build verified locally (`swift build -c release`). Unit tests will run in CI (requires Xcode). `notifyutil` verified present at `/usr/bin/notifyutil`.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add Darwin notification-based auto-refresh after upgrade actions in menubar

- Per-subsystem recheck methods (`recheckSparkdock`, `recheckBrew`, `recheckHttpProxy`, `recheckAgents`) update icon immediately

- Generation counter prevents stale full-check results from overwriting fresh per-subsystem rechecks

- 6 new unit tests covering notification names, `notifyutil` existence, and command construction


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Upgrade Action Clicked"] -- "executeTerminalCommand + recheckNotification" --> B["Terminal runs command"]
  B -- "notifyutil -p <name>" --> C["Darwin Notification Center"]
  C -- "darwinRecheckCallback" --> D["handleRecheckNotification()"]
  D -- "routes by name" --> E["recheckSparkdock / recheckBrew / recheckHttpProxy / recheckAgents"]
  E -- "checkGeneration++" --> F["Run async check"]
  F -- "MainActor.run" --> G["refreshUI()"]
  G --> H["Status Icon Updated"]
  I["checkForUpdates() full check"] -- "generation guard" --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.swift</strong><dd><code>Darwin notification-driven per-subsystem recheck after upgrades</code></dd></summary>
<hr>

src/menubar-app/Sources/SparkdockManager/main.swift

<ul><li>Added <code>RecheckNotification</code> enum with Darwin notification name constants <br>for each subsystem<br> <li> Added <code>darwinRecheckCallback</code> C-compatible callback and <br><code>setupRecheckObservers()</code> / <code>handleRecheckNotification()</code> methods<br> <li> Added per-subsystem recheck methods (<code>recheckSparkdock</code>, <code>recheckBrew</code>, <br><code>recheckHttpProxy</code>, <code>recheckAgents</code>) and <code>refreshUI()</code> helper<br> <li> Added <code>checkGeneration</code> counter to discard stale full-check results when <br>a per-subsystem recheck is newer<br> <li> Updated <code>executeTerminalCommand</code> to accept optional <code>recheckNotification</code> <br>and append <code>notifyutil -p</code> call to the terminal command<br> <li> Updated all four upgrade actions to pass their respective recheck <br>notification names</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/429/files#diff-c4b5607bd6e4ee471f9aab272ec206626d881d43c63740b61cf8fe23d6176718">+140/-9</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SparkdockManagerTests.swift</strong><dd><code>New unit tests for Darwin recheck notification logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/menubar-app/Tests/SparkdockManagerTests/SparkdockManagerTests.swift

<ul><li>Added 6 new tests covering notification name uniqueness, correct <br>prefix, count of subsystems, <code>notifyutil</code> path existence, command <br>appending with notification, and command passthrough without <br>notification</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/429/files#diff-ffaa9e6f1fd7e3d81d6bbd58f3503e36c71ef9dda693fb627466e66263faff84">+66/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Changelog entry for menubar auto-refresh feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added changelog entry describing the menubar auto-refresh behavior <br>after upgrade actions</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/429/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

