### PR TITLE
feat(shell): add ~/.local/bin to default zsh PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `~/.local/bin` to default zsh PATH for user-local binaries (XDG convention), auto-creating the directory if missing
 - Added orphan cleanup to `sparkdock-agents-sync`: detects and removes managed skills/agent profiles no longer in upstream, with `--force` to remove locally modified orphans
 - Added orphan detection to `sparkdock-agents-status`: flags resources removed from upstream as `orphan` type with cleanup hint
 - Added DESCRIPTION column to `sjust sf-agents-status` tables, reading short descriptions from upstream `catalog.json` with tab-delimited rendering to support commas in descriptions

--- a/config/shell/init.zsh
+++ b/config/shell/init.zsh
@@ -17,8 +17,9 @@ HOMEBREW_PREFIX="/opt/homebrew"
 
 # Ensure ~/.local/bin exists and is on PATH (user-local binaries, XDG convention).
 [[ -d ~/.local/bin ]] || mkdir -p ~/.local/bin
-if [[ ":${PATH}:" != *":${HOME}/.local/bin:"* ]]; then
-  export PATH="${HOME}/.local/bin:${PATH}"
+if (( ! ${path[(Ie)${HOME}/.local/bin]} )); then
+  path=("${HOME}/.local/bin" ${path})
+  export PATH
 fi
 
 # Add local zsh functions directory to fpath (skip if already present).

--- a/config/shell/init.zsh
+++ b/config/shell/init.zsh
@@ -15,6 +15,12 @@ HOMEBREW_PREFIX="/opt/homebrew"
 : "${SPARKDOCK_ENABLE_FZF:=1}"       # Enabled by default
 : "${SPARKDOCK_ENABLE_ATUIN:=0}"     # Disabled by default
 
+# Ensure ~/.local/bin exists and is on PATH (user-local binaries, XDG convention).
+[[ -d ~/.local/bin ]] || mkdir -p ~/.local/bin
+if [[ ":${PATH}:" != *":${HOME}/.local/bin:"* ]]; then
+  export PATH="${HOME}/.local/bin:${PATH}"
+fi
+
 # Add local zsh functions directory to fpath (skip if already present).
 if [[ -d ~/.local/share/zsh/site-functions ]] && (( ! ${fpath[(Ie)${HOME}/.local/share/zsh/site-functions]} )); then
   fpath+=~/.local/share/zsh/site-functions


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

- Adds `~/.local/bin` to the default zsh PATH in `config/shell/init.zsh`, auto-creating the directory if missing
- Follows the same idempotent pattern already used for `fpath` (check before adding, skip duplicates)
- Uses the XDG/freedesktop convention for user-local executables

## Motivation

Multiple team members reported `command not found` errors when symlinking binaries (e.g. `dri`) to `~/.local/bin`. Sparkdock's shell config had no PATH management — this adds the standard user-local bin directory.

Closes #433


___

### **PR Type**
Enhancement


___

### **Description**
- Add `~/.local/bin` to default zsh PATH in `init.zsh`

- Auto-create `~/.local/bin` directory if missing

- Idempotent check prevents duplicate PATH entries

- Update `CHANGELOG.md` with new feature entry


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["init.zsh sourced"] -- "check dir" --> B{"~/.local/bin exists?"}
  B -- "no" --> C["mkdir -p ~/.local/bin"]
  B -- "yes" --> D{"PATH contains ~/.local/bin?"}
  C --> D
  D -- "no" --> E["prepend to PATH"]
  D -- "yes" --> F["skip (idempotent)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>init.zsh</strong><dd><code>Add ~/.local/bin to default zsh PATH</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/shell/init.zsh

<ul><li>Creates <code>~/.local/bin</code> directory if it does not exist<br> <li> Prepends <code>~/.local/bin</code> to <code>PATH</code> if not already present<br> <li> Follows idempotent pattern consistent with existing <code>fpath</code> management</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/434/files#diff-6f5a4c2803486c058e67acac32722458b5e867cf402cc35a5965dd44867e436a">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document ~/.local/bin PATH change in changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added entry documenting <code>~/.local/bin</code> PATH addition under the <code>Added</code> <br>section</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/434/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

