### PR TITLE
feat(shell): use dynamic SPARKDOCK_ROOT instead of hardcoded /opt/sparkdock

### DIFF
--- a/sjust/libs/libshell.sh
+++ b/sjust/libs/libshell.sh
@@ -6,6 +6,11 @@
 # shellcheck source=../../bin/common/logging.sh
 source "$(dirname "${BASH_SOURCE[0]:-$0}")/../../bin/common/logging.sh"
 
+# Resolve SPARKDOCK_ROOT: honor env override, otherwise derive from this script's location.
+# libshell.sh lives at <sparkdock_root>/sjust/libs/libshell.sh
+: "${SPARKDOCK_ROOT:=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../.." && pwd)}"
+export SPARKDOCK_ROOT
+
 # Check if a user file is symlinked to Sparkdock's default
 # Usage: check_sparkdock_symlink <user_file> <sparkdock_file>
 # Returns:
@@ -192,11 +197,11 @@ sparkdock_write_shell_config() {
     {
         echo ""
         echo "# Sparkdock shell enhancements"
-        echo "if [ -f /opt/sparkdock/config/shell/sparkdock.zshrc ]; then"
+        echo "if [ -f ${SPARKDOCK_ROOT}/config/shell/sparkdock.zshrc ]; then"
         printf '    export SPARKDOCK_ENABLE_STARSHIP=%s\n' "${DEFAULT_STARSHIP}"
         printf '    export SPARKDOCK_ENABLE_FZF=%s\n' "${DEFAULT_FZF}"
         printf '    export SPARKDOCK_ENABLE_ATUIN=%s\n' "${DEFAULT_ATUIN}"
-        echo "    source /opt/sparkdock/config/shell/sparkdock.zshrc;"
+        echo "    source ${SPARKDOCK_ROOT}/config/shell/sparkdock.zshrc"
         echo "fi"
     } >> "${zshrc_file}"
 }
@@ -259,20 +264,20 @@ sparkdock_print_shell_overview() {
 
     echo ""
     echo "📚 Reference files:"
-    echo "   • Primary config: /opt/sparkdock/config/shell/sparkdock.zshrc"
-    echo "   • Documentation:  /opt/sparkdock/config/shell/README.md"
-    echo "   • Alias catalog:  /opt/sparkdock/config/shell/aliases.zsh"
+    echo "   • Primary config: ${SPARKDOCK_ROOT}/config/shell/sparkdock.zshrc"
+    echo "   • Documentation:  ${SPARKDOCK_ROOT}/config/shell/README.md"
+    echo "   • Alias catalog:  ${SPARKDOCK_ROOT}/config/shell/aliases.zsh"
     echo ""
     echo "✏️ Personal overrides (auto-sourced after Sparkdock):"
     echo "   ~/.config/spark/shell.zsh  — keep custom aliases and exports here"
     echo ""
     echo "Block to be appended to ${zshrc_file}:"
     echo ""
-    echo "+ if [ -f /opt/sparkdock/config/shell/sparkdock.zshrc ]; then"
+    echo "+ if [ -f ${SPARKDOCK_ROOT}/config/shell/sparkdock.zshrc ]; then"
     echo "+     export SPARKDOCK_ENABLE_STARSHIP=${DEFAULT_STARSHIP}"
     echo "+     export SPARKDOCK_ENABLE_FZF=${DEFAULT_FZF}"
     echo "+     export SPARKDOCK_ENABLE_ATUIN=${DEFAULT_ATUIN}"
-    echo "+     source /opt/sparkdock/config/shell/sparkdock.zshrc;"
+    echo "+     source ${SPARKDOCK_ROOT}/config/shell/sparkdock.zshrc"
     echo "+     # Set SPARKDOCK_ENABLE_* above this block to change defaults"
     echo "+ fi"
     echo ""
@@ -294,7 +299,7 @@ sparkdock_print_shell_overview() {
 sparkdock_setup_ghostty_config() {
     local USER_CONFIG="${HOME}/.config/ghostty/config"
     local USER_OVERRIDES="${HOME}/.config/ghostty/user"
-    local SPARKDOCK_CONFIG="/opt/sparkdock/config/shell/config/ghostty/config"
+    local SPARKDOCK_CONFIG="${SPARKDOCK_ROOT}/config/shell/config/ghostty/config"
 
     # Check if user config already exists and is not empty
     if [[ -f "${USER_CONFIG}" && -s "${USER_CONFIG}" ]]; then
@@ -340,13 +345,13 @@ sparkdock_setup_ghostty_config() {
     echo "📦 Setting up Ghostty configuration with two-file setup..."
     mkdir -p "$(dirname "${USER_CONFIG}")"
 
-    cat > "${USER_CONFIG}" << 'EOF'
+    cat > "${USER_CONFIG}" << EOF
 # Ghostty Configuration
 # This file loads Sparkdock's base configuration and allows you to override settings.
 # Documentation: https://ghostty.org/docs/config
 
 # Load Sparkdock base configuration
-config-file = /opt/sparkdock/config/shell/config/ghostty/config
+config-file = ${SPARKDOCK_CONFIG}
 
 # Load user configuration/overrides (? prefix = optional, no error if missing)
 config-file = ?user

--- a/sjust/recipes/03-shell.just
+++ b/sjust/recipes/03-shell.just
@@ -1,14 +1,18 @@
 
+# Sparkdock root, resolved from this recipe file's location.
+_sparkdock_root := clean(source_directory() / "../..")
+
 # Enable Sparkdock shell enhancements in your zshrc.
 # Pass "force" as argument to override declined state: sjust shell-enable force
 [group('shell')]
 shell-enable $force="false":
     #!/usr/bin/env bash
     set -euo pipefail
+    export SPARKDOCK_ROOT="{{_sparkdock_root}}"
     source "{{source_directory()}}/../libs/libshell.sh"
 
     ZSHRC_FILE="${HOME}/.zshrc"
-    SPARKDOCK_CHECK_LINE="if [ -f /opt/sparkdock/config/shell/sparkdock.zshrc ]; then"
+    SPARKDOCK_CHECK_LINE="if [ -f ${SPARKDOCK_ROOT}/config/shell/sparkdock.zshrc ]; then"
     DECLINED_FILE="${HOME}/.config/spark/.shell-enable-declined"
 
     # Create zshrc if it doesn't exist
@@ -80,10 +84,11 @@ shell-enable $force="false":
 shell-disable:
     #!/usr/bin/env bash
     set -euo pipefail
+    export SPARKDOCK_ROOT="{{_sparkdock_root}}"
     source "{{source_directory()}}/../libs/libshell.sh"
 
     ZSHRC_FILE="${HOME}/.zshrc"
-    SPARKDOCK_CHECK_LINE="if [ -f /opt/sparkdock/config/shell/sparkdock.zshrc ]; then"
+    SPARKDOCK_CHECK_LINE="if [ -f ${SPARKDOCK_ROOT}/config/shell/sparkdock.zshrc ]; then"
 
     if ! grep -qF "${SPARKDOCK_CHECK_LINE}" "${ZSHRC_FILE}"; then
         echo "ℹ️  Sparkdock shell enhancements are not enabled in ${ZSHRC_FILE}"
@@ -108,6 +113,7 @@ shell-disable:
 shell-info:
     #!/usr/bin/env bash
     set -euo pipefail
+    export SPARKDOCK_ROOT="{{_sparkdock_root}}"
     source "{{source_directory()}}/../libs/libshell.sh"
     sparkdock_print_shell_overview "${HOME}/.zshrc" "no"
 
@@ -117,7 +123,8 @@ shell-omz-setup:
     #!/usr/bin/env bash
     set -euo pipefail
 
-    source "/opt/sparkdock/bin/common/logging.sh"
+    SPARKDOCK_ROOT="{{_sparkdock_root}}"
+    source "${SPARKDOCK_ROOT}/bin/common/logging.sh"
     log_section "Setting up oh-my-zsh and zsh plugins"
     echo ""
 
@@ -201,7 +208,7 @@ shell-omz-setup:
     echo "  - ssh-agent (built-in to oh-my-zsh)"
     echo ""
     echo "Plugins are automatically enabled when you source sparkdock.zshrc"
-    echo "Configuration is in: /opt/sparkdock/config/shell/omz-init.zsh"
+    echo "Configuration is in: ${SPARKDOCK_ROOT}/config/shell/omz-init.zsh"
     echo ""
     echo "💡 To update on-my-zsh and plugins in the future, simply re-run 'sjust shell-omz-setup'"
 
@@ -211,7 +218,7 @@ shell-starship-setup:
     @just _shell-config-setup \
         "starship" \
         "${HOME}/.config/starship.toml" \
-        "/opt/sparkdock/config/shell/config/starship/starship.toml" \
+        "{{_sparkdock_root}}/config/shell/config/starship/starship.toml" \
         "config at ~/.config/starship.toml" \
         "See https://starship.rs/config/ for configuration options"
 
@@ -221,13 +228,14 @@ shell-eza-setup:
     @just _shell-config-setup \
         "eza" \
         "${HOME}/.config/eza/theme.yml" \
-        "/opt/sparkdock/config/shell/config/eza/theme.yml" \
+        "{{_sparkdock_root}}/config/shell/config/eza/theme.yml" \
         "theme at ~/.config/eza/theme.yml" \
         "Based on Catppuccin color scheme"
 
 # Generic configuration setup helper.
 _shell-config-setup tool_name config_path sparkdock_path config_description setup_info:
     #!/usr/bin/env bash
+    export SPARKDOCK_ROOT="{{_sparkdock_root}}"
     source "{{source_directory()}}/../libs/libshell.sh"
 
     USER_CONFIG="{{config_path}}"
@@ -252,5 +260,6 @@ _shell-config-setup tool_name config_path sparkdock_path config_description setu
 [group('shell')]
 shell-ghostty-setup:
     #!/usr/bin/env bash
+    export SPARKDOCK_ROOT="{{_sparkdock_root}}"
     source "{{source_directory()}}/../libs/libshell.sh"
     sparkdock_setup_ghostty_config


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

- Introduce `SPARKDOCK_ROOT` env var (defaults to auto-detected path from script location) to replace all hardcoded `/opt/sparkdock` references in shell config recipes
- Update `libshell.sh`: auto-resolve root from `BASH_SOURCE`, use `${SPARKDOCK_ROOT}` in `sparkdock_write_shell_config()`, `sparkdock_print_shell_overview()`, and `sparkdock_setup_ghostty_config()`
- Update `03-shell.just`: add `_sparkdock_root` variable via `clean(source_directory() / \"../..\")`, export `SPARKDOCK_ROOT` in all recipes

## Why

On macOS sparkdock lives at `/opt/sparkdock`, on Linux it's cloned to `~/.local/spark/sparkdock`. The hardcoded path prevents sharing shell recipes cross-platform. This change enables the `archlinux-ansible-provisioner` to import `03-shell.just` via ajust and reuse the same `shell-enable` / `shell-info` / `shell-disable` recipes on Linux.

## Backward compatibility

- On macOS (`sjust`): `source_directory()` resolves to `/opt/sparkdock/sjust/recipes`, so `_sparkdock_root` becomes `/opt/sparkdock` — no behavior change
- `libshell.sh` auto-detects from its own path if `SPARKDOCK_ROOT` is not set — no behavior change for existing callers
- `SPARKDOCK_ROOT` can be overridden via env var for non-standard installations

Closes sparkfabrik/sparkdock#438


___

### **PR Type**
Enhancement


___

### **Description**
- Introduce `SPARKDOCK_ROOT` env var replacing hardcoded `/opt/sparkdock` paths

- Auto-detect root in `libshell.sh` from script location via `BASH_SOURCE`

- Add `_sparkdock_root` variable in `03-shell.just` using `source_directory()`

- Export `SPARKDOCK_ROOT` in all shell recipes for cross-platform compatibility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["03-shell.just\n_sparkdock_root = source_directory()/../../"] -- "export SPARKDOCK_ROOT" --> B["shell-enable / shell-disable\nshell-info / shell-omz-setup\nshell-ghostty-setup"]
  C["libshell.sh\nBASH_SOURCE auto-detect"] -- "SPARKDOCK_ROOT fallback" --> D["sparkdock_write_shell_config()\nsparkdock_print_shell_overview()\nsparkdock_setup_ghostty_config()"]
  E["SPARKDOCK_ROOT env override"] -- "honors override" --> C
  A -- "passes root" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>libshell.sh</strong><dd><code>Auto-detect and use dynamic SPARKDOCK_ROOT in libshell.sh</code></dd></summary>
<hr>

sjust/libs/libshell.sh

<ul><li>Auto-resolve <code>SPARKDOCK_ROOT</code> from <code>BASH_SOURCE</code> location if not set in <br>environment<br> <li> Export <code>SPARKDOCK_ROOT</code> for downstream use<br> <li> Replace all hardcoded <code>/opt/sparkdock</code> references with <code>${SPARKDOCK_ROOT}</code> <br>in <code>sparkdock_write_shell_config()</code>, <code>sparkdock_print_shell_overview()</code>, <br>and <code>sparkdock_setup_ghostty_config()</code><br> <li> Change heredoc delimiter from <code>'EOF'</code> to <code>EOF</code> to allow variable expansion <br>of <code>${SPARKDOCK_CONFIG}</code></ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/439/files#diff-ed569ad39d3119e88fcc51e8d426bb62253fabef3d81b35c5b9a109028b2c3a1">+15/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>03-shell.just</strong><dd><code>Replace hardcoded paths with dynamic _sparkdock_root in recipes</code></dd></summary>
<hr>

sjust/recipes/03-shell.just

<ul><li>Add <code>_sparkdock_root</code> variable computed via <code>clean(source_directory() / </code><br><code>"../..")</code><br> <li> Export <code>SPARKDOCK_ROOT</code> before sourcing <code>libshell.sh</code> in <code>shell-enable</code>, <br><code>shell-disable</code>, <code>shell-info</code>, <code>shell-ghostty-setup</code>, and <br><code>_shell-config-setup</code><br> <li> Replace hardcoded <code>/opt/sparkdock</code> in <code>SPARKDOCK_CHECK_LINE</code>, <br><code>shell-omz-setup</code> log path, and <code>shell-starship-setup</code>/<code>shell-eza-setup</code> <br>config paths<br> <li> Use <code>{{_sparkdock_root}}</code> interpolation for <code>shell-starship-setup</code> and <br><code>shell-eza-setup</code> sparkdock paths</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/439/files#diff-1ace2ecd0aa34c5137bfbfe95286b5d9beb214030ba8d34a3ee587ee9b540877">+15/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

