### PR TITLE
fix(shell): use path substring for shell-enable detection to handle quoted/unquoted variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `shell-enable` re-prompting users who already have Sparkdock shell enhancements installed, caused by quoting mismatch in the detection string after the cross-platform refactor
 - Fixed CI failure caused by `neofetch` being removed from Homebrew — dropped it from the `removed_homebrew_packages` list since the formula no longer exists
 - Fixed sjust zsh tab-completion (`_clap_dynamic_completer_sjust` not found) caused by just 1.40+ switching to dynamic clap completions — replaced sed-based renaming with a custom completion file that correctly bridges sjust to just's dynamic completer
 - Fixed Slack notification announcing already-released features by using zero-context git diff (`-U0`) to eliminate context lines that confused Claude AI

--- a/sjust/recipes/shared/05-shell.just
+++ b/sjust/recipes/shared/05-shell.just
@@ -14,7 +14,7 @@ shell-enable $force="false":
     source "{{source_directory()}}/../../libs/libshell.sh"
 
     ZSHRC_FILE="${HOME}/.zshrc"
-    SPARKDOCK_CHECK_LINE="if [ -f \"${SPARKDOCK_ROOT}/config/shell/sparkdock.zshrc\" ]; then"
+    SPARKDOCK_CHECK_STRING="${SPARKDOCK_ROOT}/config/shell/sparkdock.zshrc"
     DECLINED_FILE="${HOME}/.config/spark/.shell-enable-declined"
 
     # Create zshrc if it doesn't exist
@@ -34,8 +34,8 @@ shell-enable $force="false":
         echo ""
     fi
 
-    # Check if already enabled
-    if grep -qF "${SPARKDOCK_CHECK_LINE}" "${ZSHRC_FILE}"; then
+    # Check if already enabled (matches both quoted and unquoted path variants)
+    if grep -qF "${SPARKDOCK_CHECK_STRING}" "${ZSHRC_FILE}"; then
         echo "ℹ️  Sparkdock shell enhancements are already enabled in ${ZSHRC_FILE}"
         echo ""
         echo "If you want reinstall again:"
@@ -90,9 +90,9 @@ shell-disable:
     source "{{source_directory()}}/../../libs/libshell.sh"
 
     ZSHRC_FILE="${HOME}/.zshrc"
-    SPARKDOCK_CHECK_LINE="if [ -f \"${SPARKDOCK_ROOT}/config/shell/sparkdock.zshrc\" ]; then"
+    SPARKDOCK_CHECK_STRING="${SPARKDOCK_ROOT}/config/shell/sparkdock.zshrc"
 
-    if ! grep -qF "${SPARKDOCK_CHECK_LINE}" "${ZSHRC_FILE}"; then
+    if ! grep -qF "${SPARKDOCK_CHECK_STRING}" "${ZSHRC_FILE}"; then
         echo "ℹ️  Sparkdock shell enhancements are not enabled in ${ZSHRC_FILE}"
         exit 0
     fi


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

- Fixes `shell-enable` re-prompting users who already have Sparkdock shell enhancements installed (regression from cross-platform refactor)
- Uses the resolved path substring (`${SPARKDOCK_ROOT}/config/shell/sparkdock.zshrc`) for detection instead of the full `if [ -f "..." ]; then` line, which matches both old (unquoted) and new (quoted) block formats
- Platform-aware: `SPARKDOCK_ROOT` resolves differently on macOS vs Linux, so a Linux block won't falsely satisfy detection on macOS

Closes #441


___

### **PR Type**
Bug fix


___

### **Description**
- Fix `shell-enable` re-prompting users with enhancements already installed

- Replace full `if [ -f "..." ]; then` string with path substring for detection

- Matches both quoted and unquoted variants in `~/.zshrc`

- Update `shell-disable` with same detection fix for consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["~/.zshrc content\n(unquoted path variant)"] -- "grep -qF" --> B["SPARKDOCK_CHECK_STRING\n(path substring only)"]
  C["~/.zshrc content\n(quoted path variant)"] -- "grep -qF" --> B
  B -- "match found" --> D["Already enabled\n(skip re-prompt)"]
  B -- "no match" --> E["Proceed with\ninstallation prompt"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>05-shell.just</strong><dd><code>Fix shell detection to match quoted and unquoted path variants</code></dd></summary>
<hr>

sjust/recipes/shared/05-shell.just

<ul><li>Replace <code>SPARKDOCK_CHECK_LINE</code> (full <code>if [ -f "..." ]; then</code> string) with <br><code>SPARKDOCK_CHECK_STRING</code> (path substring only) in <code>shell-enable</code><br> <li> Update <code>grep -qF</code> detection in <code>shell-enable</code> to use new path substring <br>variable<br> <li> Apply same fix to <code>shell-disable</code> command for consistency<br> <li> Add comment clarifying the detection matches both quoted and unquoted <br>path variants</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/442/files#diff-f563dce9eac61404e106e6de5e8618a369816f8733476f12e40b37ebf0b39daa">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document shell-enable detection mismatch bug fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Add entry documenting the fix for <code>shell-enable</code> re-prompting users due <br>to quoting mismatch after cross-platform refactor</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/442/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

