### PR TITLE
chore(rtk): disable RTK setup task from provisioning

### DIFF
--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -818,14 +818,6 @@
             - openspec_completion_output is not skipped
             - openspec_completion_output.rc == 0
 
-    - name: Configure RTK for LLM token optimization
-      tags: rtk
-      block:
-        - name: Run RTK setup script (Copilot + OpenCode)
-          command: "{{ dev_env_dir }}/sjust/scripts/rtk/setup.sh"
-          changed_when: true
-          become: false
-
     - name: Sync AI coding agent resources from upstream repository
       tags:
         - skills


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @francescoben._

## Summary

- Remove the Ansible task that runs `rtk setup.sh` during provisioning
- RTK binary remains installed via Homebrew but is no longer auto-configured for Copilot/OpenCode

## Context

Disabling RTK setup while we evaluate the security implications of the rtk rewrite mechanism (see #430, #443). The `sjust sf-rtk-setup` recipe remains available for manual opt-in.

Refs #430
