### PR TITLE
chore(opencode): move base config to system-wide path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ Sparkdock is an automated macOS development environment provisioner built with A
 ## Common Commands
 
 ### Running Ansible Provisioning
+
 ```bash
 # Run full system provisioning
 sparkdock
@@ -23,6 +24,7 @@ just run-ansible-playbook "http-proxy"
 ```
 
 ### SparkJust Task Runner (sjust)
+
 ```bash
 # Show available commands and list all tasks
 sjust
@@ -58,6 +60,7 @@ my-recipe $param="default":
 Without the `$` prefix, parameters require `{{param}}` interpolation in recipe lines.
 
 ### HTTP Proxy Management
+
 ```bash
 spark-http-proxy start           # Start proxy services
 spark-http-proxy stop            # Stop proxy services
@@ -65,6 +68,7 @@ spark-http-proxy status          # Check service status
 ```
 
 ### Development Workflow
+
 ```bash
 # Run specific Ansible tasks by tags
 sjust install-tags "docker,keyboard"
@@ -73,6 +77,7 @@ sjust install-tags "docker,keyboard"
 ## Architecture
 
 ### Directory Structure
+
 - `/opt/sparkdock/` - Main installation directory
 - `ansible/` - Ansible playbooks and configuration
 - `sjust/` - SparkJust task runner with recipes
@@ -83,11 +88,13 @@ sjust install-tags "docker,keyboard"
 ### Core Components
 
 **Ansible Provisioning System:**
+
 - Main playbook: `ansible/macos.yml` → `ansible/macos/macos/base.yml`
 - Package definitions: `config/packages/all-packages.yml`
 - Supports tagging for selective installation
 
 **SparkJust Task Runner:**
+
 - Wrapper around Just task runner: `sjust/sjust.sh`
 - Recipe files in `sjust/recipes/` with modular task definitions
 - User customizations via `~/.config/sjust/100-custom.just`
@@ -96,11 +103,13 @@ sjust install-tags "docker,keyboard"
 - Use `source "{{source_directory()}}/../libs/libshell.sh"` to load shared utilities
 
 **HTTP Proxy Integration:**
+
 - Clones SparkFabrik HTTP proxy to `/opt/sparkdock/http-proxy`
 - Configures DNS resolver for `.loc` domains
 - Manages SSL certificates with mkcert
 
 ### Package Management
+
 - Homebrew packages and casks defined in YAML
 - Automatic tap management and cleanup
 - Version-specific packages (Node 20, PHP 8.2)
@@ -109,6 +118,7 @@ sjust install-tags "docker,keyboard"
 ## Shell Script Standards
 
 All shell scripts must:
+
 - Use `#!/usr/bin/env bash` shebang
 - Include `set -euo pipefail` for error handling
 - Use `${variable}` syntax with braces (never bare `$variable`)
@@ -144,9 +154,16 @@ docker run --rm -v "$(pwd):/src" koalaman/shellcheck:stable /src/bin/sparkdock-a
 - Run via Docker: `docker run --rm -v "$(pwd)/src:/src" ghcr.io/astral-sh/ruff:latest format /src`
 - Lint check: `docker run --rm -v "$(pwd)/src:/src" ghcr.io/astral-sh/ruff:latest check /src`
 
+## Markdown Formatting
+
+After creating or editing any Markdown file (`.md`), **always** run the
+formatter before committing. Never format Markdown by hand -- delegate to
+the tool.
+
 ## Code Quality Standards
 
 **CRITICAL: Trailing Whitespace**
+
 - **NEVER** commit trailing whitespace (spaces/tabs at end of lines)
 - Git will warn about trailing whitespace during commits
 - Always clean up trailing whitespace before staging changes
@@ -154,6 +171,7 @@ docker run --rm -v "$(pwd):/src" koalaman/shellcheck:stable /src/bin/sparkdock-a
 - This applies to ALL files: Swift, shell scripts, YAML, Markdown, etc.
 
 **JavaScript Style**
+
 - Always use braces for `if`, `for`, `while`, and similar control statements, even for single-line bodies
 
 **CHANGELOG.md Conventions**
@@ -183,12 +201,14 @@ This project uses a daily Slack digest that parses `CHANGELOG.md` to detect and 
 A Swift-based menu bar application provides battery-efficient visual update notifications using modern async/await patterns:
 
 ### Key Features
+
 - **Event-Driven Updates**: Only checks on system wake and network connectivity changes (no periodic polling)
 - **Modern Swift Concurrency**: Uses structured concurrency with proper cancellation and timeout handling
 - **Battery Efficient**: NWPathMonitor for lightweight network monitoring
 - **Resource Debugging**: Enhanced logging for missing logo/resource troubleshooting
 
 ### Building and Testing
+
 ```bash
 cd src/menubar-app
 make build                    # Build the app
@@ -198,6 +218,7 @@ make uninstall               # Remove installation
 ```
 
 ### Integration
+
 - Built automatically during Ansible provisioning with `menubar` tag
 - Replaces old launchd-based update notifications
 - Auto-starts at login via launch agent (local development only)
@@ -211,27 +232,34 @@ Sparkdock syncs AI coding resources from the upstream `sf-awesome-copilot` repos
 - **Agent profiles**: Per-tool agent configurations (e.g., "The Architect") installed to tool-specific directories (`~/.copilot/agents/`, `~/.config/opencode/agents/`)
 
 ### Key Scripts
+
 - `bin/sparkdock-agents-sync` — Unified sync script with tool registry, skill sync, agent sync, v2 manifest
 - `bin/sparkdock-agents-status` — Status display for both skills and agent profiles
 - `bin/sparkdock-check-updates` — Accepts both `skills` and `agents` subcommands
 
 ### Tool Registry
+
 The sync script uses associative arrays to map each coding tool to its install directory and filename pattern. Adding support for a new tool requires only 2 lines (one in each array). Current tools: `copilot`, `opencode`.
 
 ### Manifest
+
 Located at `~/.cache/sparkdock/sf-skills-manifest.json`. V2 format with `skills` and `agents` top-level keys. V1 manifests upgrade organically (no migration code). Agent entries use composite keys like `the-architect/copilot`.
 
 ### Catalog Metadata
+
 The upstream repo provides `config/catalog.json` with short human-friendly descriptions for each system skill and agent. The status script reads this file from the local cache (`~/.cache/sparkdock/agent-skills/config/catalog.json`) to display a DESCRIPTION column in the table. No sync changes are needed — the file is part of the cloned cache.
 
 ### sjust Recipes (`sjust/recipes/05-ai-coding-agents.just`)
+
 - `sf-agents-refresh [force]` — Sync all resources (skills + agents)
 - `sf-agents-status` — Show status of all resources
 
 ### Ansible Tags
+
 - `ai-coding-agents` (new) and `skills` (kept for backward compat)
 
 ### OpenSpec Change
+
 Full design artifacts at `openspec/changes/unified-agents-sync/` (proposal, design, specs, tasks).
 
 ## Git Workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,10 +67,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Moved opencode base configuration from `~/.config/opencode/opencode.json` to `/Library/Application Support/opencode/opencode.json` (system-wide, root-owned) to support user-local overrides via `~/.config/opencode/opencode.json`
 - Moved shell recipes (`shell-enable`, `shell-disable`, `shell-info`, `shell-omz-setup`, `shell-starship-setup`, `shell-eza-setup`, `shell-ghostty-setup`) to shared recipes directory for cross-platform reuse via ajust on Linux
 - Extracted bashcompinit-based completions (gcloud) from `sparkdock.zshrc` into dedicated `config/shell/bashcompinit-completions.zsh` file for cleaner separation of concerns and easier addition of future bashcompinit tools (aws, terraform)
 - Replaced tmate with upterm for terminal session sharing (tmate is deprecated in Homebrew), with a transition shell shim that guides users to the new tool
-
 - Menubar app now auto-refreshes subsystem status after upgrade actions complete so the icon updates immediately
 - Changed Copilot API auth to support multiple sources (gh CLI, OpenCode) with automatic fallback on 401/403, removing the hard dependency on OpenCode for `sf-copilot-premium-usage`, `sf-copilot-model-limits`, and `sf-copilot-model-list` recipes
 - Improved `copilot-models.mjs` plain-text table output with proper column alignment when `gum` is not available, use `premium` API field for model grouping, and use unique temp file names for `gum` table rendering

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Moved opencode base configuration from `~/.config/opencode/opencode.json` to `/Library/Application Support/opencode/opencode.json` (system-wide, root-owned) to support user-local overrides via `~/.config/opencode/opencode.json`
+- Moved opencode base configuration from `~/.config/opencode/opencode.json` to `/Library/Application Support/opencode/opencode.json` (system-wide path, user-writable) to support user-local overrides via `~/.config/opencode/opencode.json`
 - Added automatic cleanup of duplicate `~/.config/opencode/opencode.json` when identical to the shipped source, with a warning when the file contains non-custom content
 - Moved shell recipes (`shell-enable`, `shell-disable`, `shell-info`, `shell-omz-setup`, `shell-starship-setup`, `shell-eza-setup`, `shell-ghostty-setup`) to shared recipes directory for cross-platform reuse via ajust on Linux
 - Extracted bashcompinit-based completions (gcloud) from `sparkdock.zshrc` into dedicated `config/shell/bashcompinit-completions.zsh` file for cleaner separation of concerns and easier addition of future bashcompinit tools (aws, terraform)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Moved opencode base configuration from `~/.config/opencode/opencode.json` to `/Library/Application Support/opencode/opencode.json` (system-wide, root-owned) to support user-local overrides via `~/.config/opencode/opencode.json`
+- Added automatic cleanup of duplicate `~/.config/opencode/opencode.json` when identical to the shipped source, with a warning when the file contains non-custom content
 - Moved shell recipes (`shell-enable`, `shell-disable`, `shell-info`, `shell-omz-setup`, `shell-starship-setup`, `shell-eza-setup`, `shell-ghostty-setup`) to shared recipes directory for cross-platform reuse via ajust on Linux
 - Extracted bashcompinit-based completions (gcloud) from `sparkdock.zshrc` into dedicated `config/shell/bashcompinit-completions.zsh` file for cleaner separation of concerns and easier addition of future bashcompinit tools (aws, terraform)
 - Replaced tmate with upterm for terminal session sharing (tmate is deprecated in Homebrew), with a transition shell shim that guides users to the new tool

--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -796,7 +796,7 @@
           become: yes
           become_method: sudo
 
-        - name: Deploy OpenCode configuration with security permissions and OpenCode provider disabled
+        - name: Deploy base OpenCode configuration
           copy:
             src: "{{ dev_env_dir }}/config/macos/opencode.json"
             dest: "/Library/Application Support/opencode/opencode.json"
@@ -808,7 +808,7 @@
 
         - name: Display OpenCode configuration status
           debug:
-            msg: "✅ OpenCode configuration deployed to /Library/Application Support/opencode/opencode.json (OpenCode provider disabled; 175 permission rules — dangerous commands are blocked or require confirmation)"
+            msg: "✅ OpenCode configuration deployed to /Library/Application Support/opencode/opencode.json (user-writable; OpenCode provider disabled; 175 permission rules — dangerous commands are blocked or require confirmation)"
 
         - name: Ensure zsh site-functions directory exists
           ansible.builtin.file:

--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -738,6 +738,11 @@
 
     - name: Configure OpenCode settings
       tags: opencode
+      vars:
+        opencode_personal_config_notice: >-
+          You can create ~/.config/opencode/opencode.json for personal
+          customizations. It will be merged with the system-wide configuration
+          shipped in /Library/Application Support/opencode/opencode.json.
       block:
         - name: Ensure OpenCode user config directory exists
           file:
@@ -745,13 +750,6 @@
             state: directory
             mode: "0755"
           become: no
-
-        - name: Notify user about personal opencode configuration
-          debug:
-            msg: >-
-              You can create ~/.config/opencode/opencode.json for personal
-              customizations. It will be merged with the system-wide configuration
-              shipped in /Library/Application Support/opencode/opencode.json.
 
         - name: Check if user-local opencode config exists
           ansible.builtin.stat:
@@ -776,6 +774,23 @@
           when:
             - user_opencode_config.stat.exists
             - opencode_config_diff is defined
+            - opencode_config_diff.rc is defined
+            - opencode_config_diff.rc == 0
+
+        - name: Notify user about personal opencode configuration
+          debug:
+            msg: "{{ opencode_personal_config_notice }}"
+
+        - name: Notify with a system notification.
+          ansible.builtin.command:
+            argv:
+              - osascript
+              - -e
+              - 'display notification "{{ opencode_personal_config_notice }}" with title "OpenCode Configuration"'
+          when:
+            - not is_non_interactive | default(false)
+            - opencode_config_diff is defined
+            - opencode_config_diff.rc is defined
             - opencode_config_diff.rc == 0
 
         - name: Warn user about non-custom opencode config
@@ -788,6 +803,7 @@
           when:
             - user_opencode_config.stat.exists
             - opencode_config_diff is defined
+            - opencode_config_diff.rc is defined
             - opencode_config_diff.rc != 0
 
         - name: Create system-wide OpenCode config directory

--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -753,6 +753,41 @@
               customizations. It will be merged with the system-wide configuration
               shipped in /Library/Application Support/opencode/opencode.json.
 
+        - name: Check if user-local opencode config exists
+          ansible.builtin.stat:
+            path: "{{ ansible_facts['env']['HOME'] }}/.config/opencode/opencode.json"
+          register: user_opencode_config
+
+        - name: Compare user-local opencode config with source
+          ansible.builtin.command:
+            cmd: >-
+              diff -q
+              "{{ ansible_facts['env']['HOME'] }}/.config/opencode/opencode.json"
+              "{{ dev_env_dir }}/config/macos/opencode.json"
+          register: opencode_config_diff
+          changed_when: false
+          failed_when: false
+          when: user_opencode_config.stat.exists
+
+        - name: Remove duplicate user-local opencode config
+          ansible.builtin.file:
+            path: "{{ ansible_facts['env']['HOME'] }}/.config/opencode/opencode.json"
+            state: absent
+          when:
+            - user_opencode_config.stat.exists
+            - opencode_config_diff.rc == 0
+
+        - name: Warn user about non-custom opencode config
+          ansible.builtin.debug:
+            msg: >-
+              The file ~/.config/opencode/opencode.json should contain only your
+              personal customizations. Any configuration already present in the
+              system-wide /Library/Application Support/opencode/opencode.json
+              can be safely removed from your local file.
+          when:
+            - user_opencode_config.stat.exists
+            - opencode_config_diff.rc != 0
+
         - name: Create system-wide OpenCode config directory
           file:
             path: "/Library/Application Support/opencode"

--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -793,8 +793,6 @@
             path: "/Library/Application Support/opencode"
             state: directory
             mode: "0755"
-            owner: "{{ ansible_facts['user_id'] }}"
-            group: "{{ ansible_facts['user_gid'] }}"
           become: yes
           become_method: sudo
 

--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -766,7 +766,7 @@
               "{{ dev_env_dir }}/config/macos/opencode.json"
           register: opencode_config_diff
           changed_when: false
-          failed_when: false
+          failed_when: opencode_config_diff.rc > 1
           when: user_opencode_config.stat.exists
 
         - name: Remove duplicate user-local opencode config
@@ -775,6 +775,7 @@
             state: absent
           when:
             - user_opencode_config.stat.exists
+            - opencode_config_diff is defined
             - opencode_config_diff.rc == 0
 
         - name: Warn user about non-custom opencode config
@@ -786,6 +787,7 @@
               can be safely removed from your local file.
           when:
             - user_opencode_config.stat.exists
+            - opencode_config_diff is defined
             - opencode_config_diff.rc != 0
 
         - name: Create system-wide OpenCode config directory

--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -793,6 +793,8 @@
             path: "/Library/Application Support/opencode"
             state: directory
             mode: "0755"
+            owner: "{{ ansible_facts['user_id'] }}"
+            group: "{{ ansible_facts['user_gid'] }}"
           become: yes
           become_method: sudo
 
@@ -801,6 +803,8 @@
             src: "{{ dev_env_dir }}/config/macos/opencode.json"
             dest: "/Library/Application Support/opencode/opencode.json"
             mode: "0644"
+            owner: "{{ ansible_facts['user_id'] }}"
+            group: "{{ ansible_facts['user_gid'] }}"
           become: yes
           become_method: sudo
 

--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -739,23 +739,39 @@
     - name: Configure OpenCode settings
       tags: opencode
       block:
-        - name: Ensure OpenCode config directory exists
+        - name: Ensure OpenCode user config directory exists
           file:
             path: "{{ ansible_facts['env']['HOME'] }}/.config/opencode"
             state: directory
             mode: "0755"
           become: no
 
+        - name: Notify user about personal opencode configuration
+          debug:
+            msg: >-
+              You can create ~/.config/opencode/opencode.json for personal
+              customizations. It will be merged with the system-wide configuration
+              shipped in /Library/Application Support/opencode/opencode.json.
+
+        - name: Create system-wide OpenCode config directory
+          file:
+            path: "/Library/Application Support/opencode"
+            state: directory
+            mode: "0755"
+          become: yes
+          become_method: sudo
+
         - name: Deploy OpenCode configuration with security permissions and OpenCode provider disabled
           copy:
             src: "{{ dev_env_dir }}/config/macos/opencode.json"
-            dest: "{{ ansible_facts['env']['HOME'] }}/.config/opencode/opencode.json"
+            dest: "/Library/Application Support/opencode/opencode.json"
             mode: "0644"
-          become: no
+          become: yes
+          become_method: sudo
 
         - name: Display OpenCode configuration status
           debug:
-            msg: "✅ OpenCode configuration deployed successfully (OpenCode provider disabled; 175 permission rules — dangerous commands are blocked or require confirmation)"
+            msg: "✅ OpenCode configuration deployed to /Library/Application Support/opencode/opencode.json (OpenCode provider disabled; 175 permission rules — dangerous commands are blocked or require confirmation)"
 
         - name: Ensure zsh site-functions directory exists
           ansible.builtin.file:

--- a/sjust/recipes/shared/01-ai-coding-agents.just
+++ b/sjust/recipes/shared/01-ai-coding-agents.just
@@ -19,7 +19,6 @@ sf-agents-status:
 
 # Check Copilot model context/output limits against the current opencode.json config.
 # Pass --update to automatically write the correct limits to opencode.json.
-# When --update is used, sudo is required to write to the system-wide config path.
 # Requires GitHub Copilot authentication (gh CLI or OpenCode).
 # Refs: https://github.com/anomalyco/models.dev/issues/1136
 #       https://github.com/anomalyco/opencode/issues/16129
@@ -31,11 +30,7 @@ sf-copilot-model-limits *args='':
         echo "ERROR: Node.js is required but not found."
         exit 1
     fi
-    if [[ " {{args}} " == *" --update "* ]]; then
-        sudo node "{{sparkdock_path}}/sjust/scripts/copilot-models.mjs" {{args}}
-    else
-        node "{{sparkdock_path}}/sjust/scripts/copilot-models.mjs" {{args}}
-    fi
+    node "{{sparkdock_path}}/sjust/scripts/copilot-models.mjs" {{args}}
 
 # List available Copilot model IDs (one per line). Useful for scripting with machine names.
 # Requires GitHub Copilot authentication (gh CLI or OpenCode).

--- a/sjust/recipes/shared/01-ai-coding-agents.just
+++ b/sjust/recipes/shared/01-ai-coding-agents.just
@@ -19,6 +19,7 @@ sf-agents-status:
 
 # Check Copilot model context/output limits against the current opencode.json config.
 # Pass --update to automatically write the correct limits to opencode.json.
+# When --update is used, sudo is required to write to the system-wide config path.
 # Requires GitHub Copilot authentication (gh CLI or OpenCode).
 # Refs: https://github.com/anomalyco/models.dev/issues/1136
 #       https://github.com/anomalyco/opencode/issues/16129
@@ -30,7 +31,11 @@ sf-copilot-model-limits *args='':
         echo "ERROR: Node.js is required but not found."
         exit 1
     fi
-    node "{{sparkdock_path}}/sjust/scripts/copilot-models.mjs" {{args}}
+    if [[ " {{args}} " == *" --update "* ]]; then
+        sudo node "{{sparkdock_path}}/sjust/scripts/copilot-models.mjs" {{args}}
+    else
+        node "{{sparkdock_path}}/sjust/scripts/copilot-models.mjs" {{args}}
+    fi
 
 # List available Copilot model IDs (one per line). Useful for scripting with machine names.
 # Requires GitHub Copilot authentication (gh CLI or OpenCode).

--- a/sjust/scripts/copilot-models.mjs
+++ b/sjust/scripts/copilot-models.mjs
@@ -168,7 +168,20 @@ async function updateLocalConfig(modelsBlock) {
         "Run the sparkdock provisioner to create it: sparkdock",
     );
   }
-  await writeFile(OPENCODE_JSON_PATH, JSON.stringify(config, null, 2) + "\n");
+  try {
+    await writeFile(
+      OPENCODE_JSON_PATH,
+      JSON.stringify(config, null, 2) + "\n",
+    );
+  } catch (err) {
+    if (err.code === "EACCES") {
+      fail(
+        `Permission denied writing to ${OPENCODE_JSON_PATH}.\n` +
+          "Run the sparkdock provisioner to fix file ownership: sparkdock",
+      );
+    }
+    throw err;
+  }
 
   const count = Object.keys(modelsBlock).length;
   if (source !== OPENCODE_JSON_PATH) {

--- a/sjust/scripts/copilot-models.mjs
+++ b/sjust/scripts/copilot-models.mjs
@@ -9,16 +9,13 @@
 //   https://github.com/anomalyco/opencode/issues/16129
 
 import { readFile, writeFile, mkdir } from "node:fs/promises";
-import { homedir } from "node:os";
 import path, { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { fail, fetchWithAuth, BASE_HEADERS } from "./lib/copilot-auth.mjs";
 import { printTable } from "./lib/gum.mjs";
 
-const OPENCODE_JSON_PATH = path.join(
-  homedir(),
-  ".config/opencode/opencode.json",
-);
+const OPENCODE_JSON_PATH =
+  "/Library/Application Support/opencode/opencode.json";
 const SOURCE_CONFIG_PATH = path.resolve(
   dirname(fileURLToPath(import.meta.url)),
   "..",

--- a/sjust/scripts/copilot-models.mjs
+++ b/sjust/scripts/copilot-models.mjs
@@ -8,7 +8,7 @@
 //   https://github.com/anomalyco/models.dev/issues/1136
 //   https://github.com/anomalyco/opencode/issues/16129
 
-import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { readFile, writeFile, access } from "node:fs/promises";
 import path, { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { fail, fetchWithAuth, BASE_HEADERS } from "./lib/copilot-auth.mjs";
@@ -158,7 +158,16 @@ async function updateLocalConfig(modelsBlock) {
     config.provider["github-copilot"] = {};
   config.provider["github-copilot"].models = modelsBlock;
 
-  await mkdir(dirname(OPENCODE_JSON_PATH), { recursive: true });
+  // Verify the target directory exists (created by the sparkdock provisioner)
+  const targetDir = dirname(OPENCODE_JSON_PATH);
+  try {
+    await access(targetDir);
+  } catch {
+    fail(
+      `Directory ${targetDir} does not exist.\n` +
+        "Run the sparkdock provisioner to create it: sparkdock",
+    );
+  }
   await writeFile(OPENCODE_JSON_PATH, JSON.stringify(config, null, 2) + "\n");
 
   const count = Object.keys(modelsBlock).length;


### PR DESCRIPTION
### **User description**
Deploy opencode.json to /Library/Application Support/opencode/ (root-owned) instead of ~/.config/opencode/ to support user-local overrides. The user config directory is still created with a debug message explaining how to add personal customizations. The copilot-models script and sjust recipe are updated to use the new path, with sudo for --update writes.

Assisted-by: opencode/github-copilot/claude-opus-4.6


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Moved opencode base config from `~/.config/opencode/` to `/Library/Application Support/opencode/` (system-wide)

- Added cleanup logic for duplicate user-local opencode config files

- Updated `copilot-models.mjs` to use new system-wide path with directory existence check

- Added Markdown formatting guidelines and minor documentation improvements to `AGENTS.md`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Ansible Provisioner"] -- "creates (root-owned)" --> B["/Library/Application Support/opencode/"]
  A -- "deploys (user-owned file)" --> C["/Library/Application Support/opencode/opencode.json"]
  A -- "creates" --> D["~/.config/opencode/"]
  A -- "removes if duplicate" --> E["~/.config/opencode/opencode.json"]
  F["copilot-models.mjs"] -- "reads/writes" --> C
  G["User"] -- "personal overrides" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base.yml</strong><dd><code>Deploy opencode config to system-wide path with cleanup logic</code></dd></summary>
<hr>

ansible/macos/macos/base.yml

<ul><li>Renamed task to "Ensure OpenCode user config directory exists" (no <br>functional change)<br> <li> Added debug message explaining user-local config purpose<br> <li> Added tasks to detect and remove duplicate user-local <code>opencode.json</code> if <br>identical to source<br> <li> Added warning task when user-local config differs from source <br>(non-custom content)<br> <li> Added new task to create <code>/Library/Application Support/opencode/</code> with <br><code>become: yes</code><br> <li> Changed config deployment destination to <code>/Library/Application </code><br><code>Support/opencode/opencode.json</code> with user ownership and <code>become: yes</code></ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/446/files#diff-35e06808caf91480daa0d30bc6b6a1e4c425376bb5d3196d021dca2357bdd621">+57/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>copilot-models.mjs</strong><dd><code>Update copilot-models to use system-wide opencode config path</code></dd></summary>
<hr>

sjust/scripts/copilot-models.mjs

<ul><li>Replaced <code>homedir()</code>-based path with hardcoded <code>/Library/Application </code><br><code>Support/opencode/opencode.json</code><br> <li> Removed <code>mkdir</code> import; added <code>access</code> import for directory existence <br>check<br> <li> Replaced silent <code>mkdir</code> call with explicit directory access check and <br>clear error message pointing to provisioner</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/446/files#diff-dfb5f0bccc14c8f2e2d75e044433d74b2f6eff9fde4a569a2d533f37b555faa3">+13/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document opencode config path migration in changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added entries for moving opencode config to system-wide path<br> <li> Added entry for automatic cleanup of duplicate user-local opencode <br>config<br> <li> Minor formatting fix (removed blank line before a bullet)</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/446/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AGENTS.md</strong><dd><code>Add Markdown formatting guidelines and improve document structure</code></dd></summary>
<hr>

AGENTS.md

<ul><li>Added blank lines before code blocks and bullet lists for consistent <br>Markdown formatting<br> <li> Added new "Markdown Formatting" section requiring use of formatter <br>before committing<br> <li> Added "JavaScript Style" and "Code Quality Standards" section spacing <br>improvements</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/446/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+28/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

