### PR TITLE
chore(packages): install Homebrew bash to make the bash 4+ dependency explicit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,7 @@ sjust install-tags "docker,keyboard"
 
 ## Shell Script Standards
 
-**Bash version.** Sparkdock scripts target **bash 5.x** (Homebrew's `bash` formula). macOS still ships `/bin/bash` 3.2 because newer bash is GPLv3, but Sparkdock provisioning installs Homebrew's bash and ensures `/opt/homebrew/bin` precedes `/usr/bin` on `PATH`, so `#!/usr/bin/env bash` resolves to the modern interpreter. You can use `declare -A`, `mapfile` / `readarray`, `${arr[-1]}`, `[[ -v var ]]`, and other bash 4+ idioms freely — no need for 3.2-compat workarounds. (`bash` is listed in `config/packages/all-packages.yml`.)
+**Bash version.** Sparkdock scripts target **bash 5.x** (Homebrew's `bash` formula, listed in `config/packages/all-packages.yml`). macOS still ships `/bin/bash` 3.2 because newer bash is GPLv3, so the modern interpreter is reached via Homebrew's `PATH` setup — `eval "$(/opt/homebrew/bin/brew shellenv)"` in `~/.zprofile` puts `/opt/homebrew/bin` ahead of `/usr/bin`. Sparkdock's bootstrap (`bin/install.macos`) appends that line to `~/.zprofile` only when it is the one installing Homebrew; for users who already had Homebrew before running sparkdock, the standard Homebrew install instructions are expected to have set the same line up. With that in place, `#!/usr/bin/env bash` resolves to bash 5.x. You can use `declare -A`, `mapfile` / `readarray`, `${arr[-1]}`, `[[ -v var ]]`, and other bash 4+ idioms freely — no need for 3.2-compat workarounds.
 
 All shell scripts must:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,7 @@ sjust install-tags "docker,keyboard"
 
 ## Shell Script Standards
 
-**Bash version.** Sparkdock scripts target **bash 5.x** (Homebrew's `bash` formula, listed in `config/packages/all-packages.yml`). macOS still ships `/bin/bash` 3.2 because newer bash is GPLv3, so the modern interpreter is reached via Homebrew's `PATH` setup — `eval "$(/opt/homebrew/bin/brew shellenv)"` in `~/.zprofile` puts `/opt/homebrew/bin` ahead of `/usr/bin`. Sparkdock's bootstrap (`bin/install.macos`) appends that line to `~/.zprofile` only when it is the one installing Homebrew; for users who already had Homebrew before running sparkdock, the standard Homebrew install instructions are expected to have set the same line up. With that in place, `#!/usr/bin/env bash` resolves to bash 5.x. You can use `declare -A`, `mapfile` / `readarray`, `${arr[-1]}`, `[[ -v var ]]`, and other bash 4+ idioms freely — no need for 3.2-compat workarounds.
+**Bash version.** Sparkdock targets **bash 5.x** (Homebrew's `bash` formula, listed in `config/packages/all-packages.yml`). macOS ships `/bin/bash` 3.2, but `#!/usr/bin/env bash` resolves to the Homebrew interpreter on sparkdock-provisioned machines. You can use `declare -A`, `mapfile` / `readarray`, `${arr[-1]}`, `[[ -v var ]]`, and other bash 4+ idioms freely — no need for 3.2-compat workarounds.
 
 All shell scripts must:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,8 @@ sjust install-tags "docker,keyboard"
 
 ## Shell Script Standards
 
+**Bash version.** Sparkdock scripts target **bash 5.x** (Homebrew's `bash` formula). macOS still ships `/bin/bash` 3.2 because newer bash is GPLv3, but Sparkdock provisioning installs Homebrew's bash and ensures `/opt/homebrew/bin` precedes `/usr/bin` on `PATH`, so `#!/usr/bin/env bash` resolves to the modern interpreter. You can use `declare -A`, `mapfile` / `readarray`, `${arr[-1]}`, `[[ -v var ]]`, and other bash 4+ idioms freely — no need for 3.2-compat workarounds. (`bash` is listed in `config/packages/all-packages.yml`.)
+
 All shell scripts must:
 
 - Use `#!/usr/bin/env bash` shebang

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `bash` (Homebrew formula, 5.x) to `config/packages/all-packages.yml` so Sparkdock scripts can rely on bash 4+ idioms (`declare -A`, `mapfile`, `${arr[-1]}`, etc.); macOS's stock `/bin/bash` is 3.2.57 and several existing scripts (`bin/common/skills-symlink-shim.sh`, `bin/sparkdock-agents-sync`) already required this implicitly via Homebrew's `PATH` ordering — this commit makes the dependency explicit
 - Added `~/.local/bin` to default zsh PATH for user-local binaries (XDG convention), auto-creating the directory if missing
 - Added automatic disabling of gcloud usage reporting during Google Cloud SDK configuration (both in Ansible provisioning and `sjust system-gcloud-reconfigure`)
 - Added orphan cleanup to `sparkdock-agents-sync`: detects and removes managed skills/agent profiles no longer in upstream, with `--force` to remove locally modified orphans

--- a/config/packages/all-packages.yml
+++ b/config/packages/all-packages.yml
@@ -27,6 +27,10 @@ cask_packages:
   - copilot-cli
 
 homebrew_packages:
+  # Modern bash (5.x). macOS still ships /bin/bash 3.2 because bash 4+ is GPLv3.
+  # Several sparkdock scripts use bash-4 idioms (declare -A, mapfile) and rely
+  # on Homebrew's bash being first on PATH; making the dependency explicit here.
+  - bash
   # Cloud Tools
   - awscli
   - chafa


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

Closes #453.

## Summary

macOS still ships `/bin/bash` 3.2.57 (released 2007) because bash 4+ is GPLv3 and Apple won't ship it. Several sparkdock scripts already use bash 4+ idioms:

- `bin/common/skills-symlink-shim.sh` line 33 uses `declare -A TOOL_SKILLS_DIR=(...)`
- `bin/sparkdock-agents-sync` uses associative arrays and `mapfile`

These scripts work in practice because Sparkdock provisions Homebrew first and `/opt/homebrew/bin` precedes `/usr/bin` on `PATH` after `brew shellenv`. So `#!/usr/bin/env bash` resolves to Homebrew's bash 5.x. But the dependency is **invisible** — there's no provisioning step that guarantees brew bash is installed, and a user with a misconfigured PATH (or a script that runs before `shellenv` is sourced) can still get bash 3.2 and a cryptic `declare: -A: invalid option`.

## Change

- `config/packages/all-packages.yml` — add `bash` to `homebrew_packages` (one line + 3 explanatory comment lines).
- `AGENTS.md` — document the bash 5.x target under "Shell Script Standards".
- `CHANGELOG.md` — single entry under `### Added`.

## Why this is the conventional answer

Adding `bash` to Homebrew is the de-facto standard in macOS dev-environment playbooks (geerlingguy/mac-dev-playbook, mathias-bynens/.macos, freeCodeCamp dev guides). macOS itself moved the default login shell to zsh in 2019 — bash 3.2 is a legacy compatibility blob, not a target to write against.

## Out of scope

- **`bash-completion` is NOT added.** Sparkdock users run zsh interactively (the installer `chsh`s to zsh, AGENTS.md is zsh-first). `bash-completion@2` only adds value for interactive bash sessions, which Sparkdock effectively doesn't have.
- **No existing scripts are changed.** They already work via the implicit dependency; this PR just makes it explicit and supported. (Future scripts — e.g., the macOS-defaults work in #114 — can rely on the explicit dependency from day one.)

## Test plan

- [x] `config/packages/all-packages.yml` parses as valid YAML; `bash` appears in `homebrew_packages`
- [x] `ajust format-md AGENTS.md CHANGELOG.md` clean
- [ ] CI: `test-ansible-playbook` (macos-15 + macos-26) installs the new package alongside the existing 57; `test-sjust` continues to pass
- [ ] Local: `brew list bash` reports v5.x after running `sparkdock` on a fresh Apple Silicon Mac