### PR TITLE
feat(menubar): add AI Development playbook link to menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added "AI Development - Where We Are" playbook link to menu bar app Company section
 - Added Claude Code (`claude-code` brew cask) to default provisioned packages
 - Added `setup_claude()` to RTK setup for Claude Code global hook integration via `rtk init -g --auto-patch`
 - Added `config/rtk/exclude-commands.toml` and RTK setup logic that bootstraps RTK's own `config.toml` when needed, then rewrites only `exclude_commands` with Sparkdock's destructive shortlist (including `k`, `tf`, and `d` alias assumptions) so dangerous commands bypass RTK rewrite

--- a/src/menubar-app/Sources/SparkdockManager/Resources/menu.json
+++ b/src/menubar-app/Sources/SparkdockManager/Resources/menu.json
@@ -34,6 +34,11 @@
             "title": "Universal Definition of Done",
             "type": "url",
             "url": "https://playbook.sparkfabrik.com/tools-and-policies/universal-dod"
+          },
+          {
+            "title": "AI Development - Where We Are",
+            "type": "url",
+            "url": "https://playbook.sparkfabrik.com/ai-development/where-we-are"
           }
         ]
       }


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

- Adds "AI Development - Where We Are" link to the menu bar app's Company section
- Links to https://playbook.sparkfabrik.com/ai-development/where-we-are
- Updated CHANGELOG.md