### PR TITLE
fix(opencode): remove overly-broaD permission pattern blocking git operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `coreutils` (GNU core utilities) to default Homebrew packages
 - Added "AI Development - Where We Are" playbook link to menu bar app Company section
 - Added Claude Code (`claude-code` brew cask) to default provisioned packages
 - Added `setup_claude()` to RTK setup for Claude Code global hook integration via `rtk init -g --auto-patch`
@@ -119,6 +120,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Removed `*dd *` permission pattern from OpenCode config — the wildcard prefix caused false positives on any command containing `dd ` (e.g., `git add`) by matching the substring, effectively blocking all `git add` operations
 - Fixed all 113 OpenCode deny/ask permission patterns missing leading `*` wildcard, preventing command prefix bypass (e.g., `rtk git push --force`, `env rm -rf /`, `time kubectl delete`) from evading safety rules
 - Fixed `shell-enable` re-prompting users who already have Sparkdock shell enhancements installed, caused by quoting mismatch in the detection string after the cross-platform refactor
 - Fixed CI failure caused by `neofetch` being removed from Homebrew — dropped it from the `removed_homebrew_packages` list since the formula no longer exists

--- a/config/macos/opencode.json
+++ b/config/macos/opencode.json
@@ -111,7 +111,6 @@
       "*halt*": "deny",
       "*poweroff*": "deny",
 
-      "*dd *": "deny",
       "*mkfs*": "deny",
       "*fdisk*": "deny",
       "*parted*": "deny",

--- a/config/packages/all-packages.yml
+++ b/config/packages/all-packages.yml
@@ -32,6 +32,7 @@ homebrew_packages:
   # Several sparkdock scripts use bash-4 idioms (declare -A, mapfile) and rely
   # on Homebrew's bash being first on PATH; making the dependency explicit here.
   - bash
+  - coreutils
   # Cloud Tools
   - awscli
   - chafa


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

- **Removes the `*dd *` permission pattern** from `config/macos/opencode.json` — the wildcard prefix caused false positives on any command containing the substring `dd ` (e.g., `git add`), effectively blocking all git staging operations
- **Includes `coreutils`** (GNU core utilities) in default Homebrew packages

## Root cause

Commit 9ba94f4 changed permission patterns from prefix-only (`dd *`) to wildcard-prefix (`*dd *`) for consistency. However, `*dd *` matches `git add file` because `add ` contains the substring `dd `. This made it impossible for OpenCode to run any `git add` command.
