### PR TITLE
fix(opencode): add word-boundary dd deny rule to prevent false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed OpenCode `dd` deny rule to use start-of-command matching (`"dd *"`) instead of overly broad glob (`"*dd *"`), preventing false positives on commands like `git add`
 - Fixed CI failure caused by `neofetch` being removed from Homebrew — dropped it from the `removed_homebrew_packages` list since the formula no longer exists
 - Fixed sjust zsh tab-completion (`_clap_dynamic_completer_sjust` not found) caused by just 1.40+ switching to dynamic clap completions — replaced sed-based renaming with a custom completion file that correctly bridges sjust to just's dynamic completer
 - Fixed Slack notification announcing already-released features by using zero-context git diff (`-U0`) to eliminate context lines that confused Claude AI


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

- Adds `"* dd *": "deny"` pattern to OpenCode permissions config to deny `dd` invoked via wrappers (e.g. `env dd`, `sudo dd`)
- The existing `"dd *"` rule only catches `dd` at the start of a command; the new pattern catches it mid-command
- Prevents the security regression from the earlier removal of the overly broad `"*dd *"` glob which caused false positives on commands like `git add`