### PR TITLE
feat(rtk): exclude informationally critical commands from RTK output filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Expanded RTK `exclude_commands` to cover informationally critical commands (`git diff`, `git log`, `git status`, `tsc`, `helm template`, `ls`, `pip list`) where RTK's output filtering silently loses or rewrites data that AI agents rely on — upstream fixes filed (rtk-ai/rtk#1852, #1853, #1854), remove patterns as they're released
 - Simplified Copilot RTK helper instructions to focus on `rtk-run`, concise command examples, quoted shell operators, and raw-command fallback
 - Reworked RTK setup to support Claude Code (global hook), OpenCode (plugin), and Copilot (helper + instructions with `rtk-run` for high-output local commands, but raw commands for destructive, infrastructure, and remote-state actions) while preserving RTK's base config and always rewriting Sparkdock-managed `exclude_commands`
 - Restored automatic RTK setup in macOS provisioning now that Sparkdock only rewrites `exclude_commands` and verifies the integration in CI

--- a/config/rtk/exclude-commands.toml
+++ b/config/rtk/exclude-commands.toml
@@ -1,5 +1,6 @@
 [hooks]
 exclude_commands = [
+  # --- Destructive operations (prevent accidental data loss) ---
   "^git push(?: .*)?(?: --force| -f)(?:$| )",
   "git reset --hard",
   "^(?:kubectl|k)(?: .*)? (?:apply|delete|patch|replace)(?:$| )",
@@ -12,4 +13,24 @@ exclude_commands = [
   "^(?:gh|glab)(?: .*)? (?:merge|close|delete|destroy|cancel|disable)(?:$| )",
   "^gcloud(?: .*)? destroy(?:$| )",
   "^gcloud (?:projects delete|sql instances delete|storage rm|storage buckets delete)(?:$| )",
+  # --- Informationally critical (wrong output worse than verbose output) ---
+  # RTK's output filters for these commands silently lose or rewrite data that
+  # AI agents rely on for decision-making. Verified on RTK v0.39.0.
+  # Upstream fixes filed — remove patterns as PRs are merged and released.
+  # Tracking issue: sparkfabrik/sparkdock#460
+  #
+  # git diff: drops context lines before first change (rtk-ai/rtk#1852, PR #1855)
+  "^git(?: .*)? diff(?:$| )",
+  # git log: injects --no-merges, hides merge commits (rtk-ai/rtk#1853, PR #1856)
+  "^git(?: .*)? log(?:$| )",
+  # git status: loses detached HEAD commit SHA (rtk-ai/rtk#1854, PR #1857)
+  "^git(?: .*)? status(?:$| )",
+  # tsc: can print "No errors found" when errors exist (rtk-ai/rtk#1772)
+  "^(?:npx )?tsc(?:$| )",
+  # helm template: TOML filter caps at 40 lines, silently drops manifests (rtk-ai/rtk#1626)
+  "^helm(?: .*)? template(?:$| )",
+  # ls: filters .env and 20+ dirs via NOISE_DIRS list in ls.rs
+  "^ls(?:$| )",
+  # pip list: groups by letter, shows max 10 per group, hides most of the environment
+  "^pip list(?:$| )",
 ]

--- a/sjust/recipes/shared/05-rtk.just
+++ b/sjust/recipes/shared/05-rtk.just
@@ -5,3 +5,4 @@
 [group('ai-coding-agents')]
 sf-rtk-setup:
     {{sparkdock_path}}/sjust/scripts/rtk/setup.sh
+

--- a/sjust/scripts/rtk/verify-setup.sh
+++ b/sjust/scripts/rtk/verify-setup.sh
@@ -94,8 +94,9 @@ main() {
     fi
 
     log_info "Running RTK smoke tests..."
-    rtk git status > /dev/null
-    "${rtk_run}" git status > /dev/null
+    # Use git branch (not git status) because git status is in exclude_commands
+    rtk git branch > /dev/null
+    "${rtk_run}" git branch > /dev/null
 
     local raw_output
     raw_output=$("${rtk_run}" printf hello)
@@ -114,11 +115,11 @@ main() {
     local rewrite_output
     local rewrite_rc
     set +e
-    rewrite_output=$(rtk rewrite "git status" 2> /dev/null)
+    rewrite_output=$(rtk rewrite "git branch" 2> /dev/null)
     rewrite_rc=$?
     set -e
 
-    if [[ "${rewrite_output}" != "rtk git status" ]]; then
+    if [[ "${rewrite_output}" != "rtk git branch" ]]; then
         log_error "Unexpected rewrite output: ${rewrite_output}"
         exit 1
     fi
@@ -159,6 +160,23 @@ main() {
 
     if [[ "${gh_rc}" -ne 1 ]]; then
         log_error "Expected gh exclusion to exit 1, got ${gh_rc}"
+        exit 1
+    fi
+
+    local git_status_output
+    local git_status_rc
+    set +e
+    git_status_output=$(rtk rewrite "git status" 2> /dev/null)
+    git_status_rc=$?
+    set -e
+
+    if [[ -n "${git_status_output}" ]]; then
+        log_error "Excluded git status was rewritten: ${git_status_output}"
+        exit 1
+    fi
+
+    if [[ "${git_status_rc}" -ne 1 ]]; then
+        log_error "Expected git status exclusion to exit 1, got ${git_status_rc}"
         exit 1
     fi
 


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

- Adds `exclude_commands` patterns for 7 informationally critical commands where RTK's output filtering silently loses or rewrites data that AI agents rely on
- Upstream fixes filed for the 3 git bugs we found — patterns can be removed as fixes are released

## Excluded Commands

| Command | Bug | Upstream |
|---------|-----|----------|
| `git diff` | Drops context lines before first change | [rtk-ai/rtk#1852](https://github.com/rtk-ai/rtk/issues/1852), [PR #1855](https://github.com/rtk-ai/rtk/pull/1855) |
| `git log` | Injects `--no-merges`, hides merge commits | [rtk-ai/rtk#1853](https://github.com/rtk-ai/rtk/issues/1853), [PR #1856](https://github.com/rtk-ai/rtk/pull/1856) |
| `git status` | Loses detached HEAD commit SHA | [rtk-ai/rtk#1854](https://github.com/rtk-ai/rtk/issues/1854), [PR #1857](https://github.com/rtk-ai/rtk/pull/1857) |
| `tsc` | Fabricates "No errors found" | [rtk-ai/rtk#1772](https://github.com/rtk-ai/rtk/issues/1772) |
| `helm template` | Drops K8s manifests at ~40 lines | [rtk-ai/rtk#1626](https://github.com/rtk-ai/rtk/issues/1626) |
| `ls` | Hides .env, node_modules, etc. | — |
| `pip list` | Groups + truncates package list | — |

## Follow-up

Tracking issue to remove patterns once upstream fixes land: #464

Refs: #460