### PR TITLE
chore(packages): add yq to homebrew packages

### DIFF
--- a/config/packages/all-packages.yml
+++ b/config/packages/all-packages.yml
@@ -59,6 +59,7 @@ homebrew_packages:
   - fzf
   - navi
   - jq
+  - yq
   - yadm
   - tmate
   - tmux


### PR DESCRIPTION
## Summary

- Add `yq` (YAML processor) to homebrew packages in `config/packages/all-packages.yml`
- Placed alongside `jq` as they are natural companions for JSON/YAML processing

## Test plan

- [ ] Run `sparkdock` provisioning and verify `yq` is installed
- [ ] Confirm `yq --version` works after provisioning

Closes #462