### PR TITLE
fix(caveman): improve copilot symlink log message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Improved `sf-caveman-install` log message when Copilot instructions file is a symlink — now reports whether the symlink target already contains caveman rules instead of a misleading "skipping (managed externally)" message
 - Fixed caveman setup breaking OpenCode startup by removing incompatible `cavecrew-*.md` agent files that use a YAML `tools` array instead of the `permission` object OpenCode expects ([caveman#386](https://github.com/JuliusBrussee/caveman/issues/386))
 - Removed `*dd *` permission pattern from OpenCode config — the wildcard prefix caused false positives on any command containing `dd ` (e.g., `git add`) by matching the substring, effectively blocking all `git add` operations
 - Fixed all 113 OpenCode deny/ask permission patterns missing leading `*` wildcard, preventing command prefix bypass (e.g., `rtk git push --force`, `env rm -rf /`, `time kubectl delete`) from evading safety rules

--- a/sjust/scripts/caveman/setup.sh
+++ b/sjust/scripts/caveman/setup.sh
@@ -224,7 +224,13 @@ setup_copilot() {
     local copilot_file="${HOME}/.copilot/copilot-instructions.md"
 
     if [[ -L "${copilot_file}" ]]; then
-        log_info "Copilot instructions is a symlink ($(readlink "${copilot_file}")) — skipping (managed externally)"
+        local symlink_target
+        symlink_target="$(readlink -f "${copilot_file}")"
+        if [[ -f "${symlink_target}" ]] && grep -q "caveman" "${symlink_target}" 2>/dev/null; then
+            log_info "Copilot instructions is a symlink ($(readlink "${copilot_file}")) — target already contains caveman rules"
+        else
+            log_warn "Copilot instructions is a symlink ($(readlink "${copilot_file}")) — target does NOT contain caveman rules; inject manually or remove the symlink"
+        fi
     else
         inject_with_markers "${copilot_file}" \
             "${marker_begin}" "${marker_end}" "${rule_content}"


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

When `~/.copilot/copilot-instructions.md` is a symlink (e.g., to `~/.config/opencode/AGENTS.md`), the caveman setup script logged a misleading "skipping (managed externally)" message — implying Copilot wasn't configured.

In reality, the symlink target already contains the caveman rules (injected by the OpenCode native installer), so Copilot **is** configured correctly.

This fix replaces the ambiguous log with a check: if the target contains caveman rules, it reports success; otherwise it warns that manual injection is needed.