### PR TITLE
fix(caveman): patch opencode plugin to use correct hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed caveman OpenCode plugin hooks never firing — upstream uses non-existent `session.created` and `tui.prompt.append` hooks; patched to use `chat.message` + `experimental.chat.system.transform` ([caveman#418](https://github.com/JuliusBrussee/caveman/issues/418))
 - Added a "done" banner to the GitHub Copilot section of `sf-caveman-install` mirroring the native installer output for Claude Code and OpenCode, so the Copilot install step has matching visual weight instead of finishing on a single log line
 - Improved `sf-caveman-install` log message when Copilot instructions file is a symlink — now reports whether the symlink target already contains caveman rules instead of a misleading "skipping (managed externally)" message
 - Fixed caveman setup breaking OpenCode startup by removing incompatible `cavecrew-*.md` agent files that use a YAML `tools` array instead of the `permission` object OpenCode expects ([caveman#386](https://github.com/JuliusBrussee/caveman/issues/386))

--- a/sjust/scripts/caveman/patches/opencode-plugin.js
+++ b/sjust/scripts/caveman/patches/opencode-plugin.js
@@ -1,0 +1,150 @@
+// caveman — opencode plugin
+//
+// Provides dynamic caveman mode tracking for opencode:
+// - Writes the mode flag on plugin initialization (session start)
+// - Parses user messages for /caveman commands and natural-language toggles
+// - Injects per-turn reinforcement into the system prompt
+//
+// The always-on caveman ruleset is provided separately via
+// ~/.config/opencode/AGENTS.md (Tier-3 base). This plugin handles dynamic
+// state only: flag writes, slash-command parsing, natural-language
+// activation, and per-turn reinforcement.
+//
+// Compatible with opencode >=1.15.x plugin API:
+// - Plugin factory for session initialization (runs once at load)
+// - `chat.message` for intercepting user prompts
+// - `experimental.chat.system.transform` for system prompt injection
+
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { existsSync, unlinkSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const require = createRequire(import.meta.url);
+const here = dirname(fileURLToPath(import.meta.url));
+
+function loadConfig() {
+  try { return require(join(here, 'caveman-config.cjs')); }
+  catch (e) {
+    if (e.code !== 'MODULE_NOT_FOUND') throw e;
+    return require(join(here, '..', '..', 'hooks', 'caveman-config.js'));
+  }
+}
+const config = loadConfig();
+
+const { getDefaultMode, safeWriteFlag, readFlag, VALID_MODES } = config;
+
+// Modes handled by independent skills — not selectable via /caveman <arg>.
+const INDEPENDENT_MODES = new Set(['commit', 'review', 'compress']);
+
+function opencodeConfigDir() {
+  if (process.env.XDG_CONFIG_HOME) {
+    return path.join(process.env.XDG_CONFIG_HOME, 'opencode');
+  }
+  if (process.platform === 'win32') {
+    return path.join(
+      process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming'),
+      'opencode'
+    );
+  }
+  return path.join(os.homedir(), '.config', 'opencode');
+}
+
+const flagPath = path.join(opencodeConfigDir(), '.caveman-active');
+
+function reinforcementLine(mode) {
+  return 'CAVEMAN MODE ACTIVE (' + mode + '). ' +
+    'Drop articles/filler/pleasantries/hedging. Fragments OK. ' +
+    'Code/commits/security: write normal.';
+}
+
+// Parse a prompt for slash-command activation or natural-language toggles.
+// Returns the new mode to write, the literal string 'off' to deactivate, or
+// null when the prompt doesn't change state.
+function parseModeChange(promptRaw) {
+  const prompt = (promptRaw || '').trim().toLowerCase();
+  if (!prompt) return null;
+
+  // Natural-language deactivation — checked before activation so "stop talking
+  // like caveman" doesn't trip the activation regex.
+  if (/\b(stop|disable|deactivate|turn off)\b.*\bcaveman\b/i.test(prompt) ||
+      /\bcaveman\b.*\b(stop|disable|deactivate|turn off)\b/i.test(prompt) ||
+      /\bnormal mode\b/i.test(prompt)) {
+    return 'off';
+  }
+
+  // Natural-language activation
+  if (/\b(activate|enable|turn on|start|talk like)\b.*\bcaveman\b/i.test(prompt) ||
+      /\bcaveman\b.*\b(mode|activate|enable|turn on|start)\b/i.test(prompt)) {
+    const mode = getDefaultMode();
+    return mode === 'off' ? null : mode;
+  }
+
+  // Slash-command parsing
+  if (prompt.startsWith('/caveman')) {
+    const parts = prompt.split(/\s+/);
+    const cmd = parts[0];
+    const arg = parts[1] || '';
+
+    if (cmd === '/caveman-commit')   return 'commit';
+    if (cmd === '/caveman-review')   return 'review';
+    if (cmd === '/caveman-compress') return 'compress';
+
+    if (cmd === '/caveman') {
+      if (!arg)                                     return getDefaultMode();
+      if (arg === 'off' || arg === 'stop' || arg === 'disable') return 'off';
+      if (arg === 'wenyan-full')                    return 'wenyan';
+      if (VALID_MODES.includes(arg) && !INDEPENDENT_MODES.has(arg)) return arg;
+      return null;
+    }
+  }
+
+  return null;
+}
+
+function applyModeChange(mode) {
+  if (!mode) return;
+  if (mode === 'off') {
+    try { if (existsSync(flagPath)) unlinkSync(flagPath); } catch (e) {}
+    return;
+  }
+  safeWriteFlag(flagPath, mode);
+}
+
+export const CavemanPlugin = async (_ctx) => {
+  // Initialize flag at plugin load time (equivalent to session start).
+  // The factory runs once per opencode session.
+  const mode = getDefaultMode();
+  if (mode === 'off') {
+    try { if (existsSync(flagPath)) unlinkSync(flagPath); } catch (e) {}
+  } else {
+    safeWriteFlag(flagPath, mode);
+  }
+
+  return {
+    // Intercept user messages to detect /caveman commands and
+    // natural-language mode toggles.
+    'chat.message': async (_input, output) => {
+      if (!output || !output.parts) return;
+      for (const part of output.parts) {
+        if (part && part.type === 'text' && part.text) {
+          const change = parseModeChange(part.text);
+          if (change) applyModeChange(change);
+        }
+      }
+    },
+
+    // Inject reinforcement line into system prompt when caveman is active.
+    // This fires before every LLM call, ensuring the model stays in mode.
+    'experimental.chat.system.transform': async (_input, output) => {
+      const active = readFlag(flagPath);
+      if (active && !INDEPENDENT_MODES.has(active)) {
+        output.system.push(reinforcementLine(active));
+      }
+    },
+  };
+};
+
+export default CavemanPlugin;

--- a/sjust/scripts/caveman/setup.sh
+++ b/sjust/scripts/caveman/setup.sh
@@ -169,6 +169,22 @@ setup_opencode() {
         fi
     done
 
+    # Patch: upstream plugin.js uses non-existent opencode hooks
+    # (session.created, tui.prompt.append). Replace with our fixed version
+    # that uses chat.message + experimental.chat.system.transform.
+    # Tracked: https://github.com/JuliusBrussee/caveman/issues/418
+    local plugin_patch
+    plugin_patch="$(dirname "${BASH_SOURCE[0]}")/patches/opencode-plugin.js"
+    local plugin_dest="${HOME}/.config/opencode/plugins/caveman/plugin.js"
+    if [[ -f "${plugin_patch}" ]]; then
+        if [[ -f "${plugin_dest}" ]]; then
+            cp "${plugin_patch}" "${plugin_dest}"
+            log_success "Applied opencode plugin.js patch (issue #418)"
+        else
+            log_warn "Cannot apply plugin.js patch: destination not found (${plugin_dest})"
+        fi
+    fi
+
     log_success "Caveman configured for OpenCode (plugin + skills + commands)"
 }
 


### PR DESCRIPTION
## Summary

Upstream caveman opencode plugin (`src/plugins/opencode/plugin.js`) uses `session.created` and `tui.prompt.append` hooks that **don't exist** in opencode's plugin API. The plugin loads successfully but hooks never fire — the flag file is never written and per-turn system prompt reinforcement never injected.

## Fix

Adds a post-install patch file (`sjust/scripts/caveman/patches/opencode-plugin.js`) that `setup_opencode()` copies over the broken upstream version after the installer runs.

The patched plugin uses:
- **Plugin factory** for session init (flag write)
- **`chat.message`** hook for `/caveman` command and natural-language mode detection
- **`experimental.chat.system.transform`** hook for per-turn reinforcement injection

## Upstream

- Issue: https://github.com/JuliusBrussee/caveman/issues/418
- PR: https://github.com/JuliusBrussee/caveman/pull/419

Once upstream merges the fix, we can remove the patch.

## Testing

Tested with `opencode run` (headless):
- ✅ Flag file written on session start
- ✅ `/caveman ultra` switches mode
- ✅ `stop caveman` deactivates
- ✅ System prompt reinforcement injected per-turn