### PR TITLE
feat(harness): unified agent status and sync commands

### DIFF
--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -202,7 +202,7 @@
       tags: cask
       community.general.homebrew_cask:
         name: "{{ item }}"
-        state: latest
+        state: present
         install_options: force
         sudo_password: "{{ ansible_become_pass | default(omit) }}"
       loop: "{{ all_cask_packages }}"

--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -202,7 +202,7 @@
       tags: cask
       community.general.homebrew_cask:
         name: "{{ item }}"
-        state: present
+        state: latest
         install_options: force
         sudo_password: "{{ ansible_become_pass | default(omit) }}"
       loop: "{{ all_cask_packages }}"
@@ -267,7 +267,7 @@
       tags: brew_packages
       community.general.homebrew:
         name: "{{ item }}"
-        state: present
+        state: latest
         update_homebrew: false
       loop: "{{ all_homebrew_packages }}"
       when: all_homebrew_packages | length > 0

--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -904,7 +904,10 @@
             - openspec_completion_output.rc == 0
 
     - name: Configure RTK for AI coding tools
-      tags: rtk
+      tags:
+        - rtk
+        - ai-harness
+        - ai-harness-sync
       block:
         - name: Run RTK setup script
           command: "{{ dev_env_dir }}/sjust/scripts/rtk/setup.sh"
@@ -912,17 +915,22 @@
           become: false
 
     - name: Install caveman output compression for AI coding tools
-      tags: caveman
+      tags:
+        - caveman
+        - ai-harness
+        - ai-harness-sync
       block:
         - name: Run caveman setup script
           command: "{{ dev_env_dir }}/sjust/scripts/caveman/setup.sh"
           changed_when: true
           become: false
 
-    - name: Sync AI coding agent resources from upstream repository
+    - name: Provision AI coding agent directories and permissions
       tags:
         - skills
         - ai-coding-agents
+        - ai-harness
+        - ai-harness-provision
       block:
         - name: Ensure agent cache directory exists
           file:
@@ -980,11 +988,20 @@
           become: yes
           become_method: sudo
 
+    - name: Sync AI coding agent resources from upstream repository
+      tags:
+        - skills
+        - ai-coding-agents
+        - ai-harness
+        - ai-harness-sync
+      block:
         - name: Run agent resources sync
           command: "{{ dev_env_dir }}/bin/sparkdock-agents-sync"
           become: no
           register: agents_sync_output
           changed_when: "'added' in agents_sync_output.stdout or 'updated' in agents_sync_output.stdout"
+          environment:
+            SPARKDOCK_AGENTS_FORCE: "{{ sparkdock_agents_force | default('') }}"
 
         - name: Show agent resources sync output
           debug:

--- a/bin/common/skills-symlink-shim.sh
+++ b/bin/common/skills-symlink-shim.sh
@@ -33,12 +33,17 @@ _SPARKDOCK_SKILLS_SHIM_LOADED=1
 declare -A TOOL_SKILLS_DIR=(
     [copilot]="${HOME}/.copilot/skills"
     [claude]="${HOME}/.claude/skills"
+    [opencode]="${HOME}/.config/opencode/skills"
 )
 
 declare -A TOOL_LABEL=(
     [copilot]="Copilot CLI"
     [claude]="Claude Code"
+    [opencode]="OpenCode"
 )
+
+# Tools that discover ~/.agents/skills/ natively (no symlinks needed).
+TOOLS_NATIVE_DISCOVERY=(opencode)
 
 # ============================================================================
 # Used by sparkdock-agents-sync
@@ -75,6 +80,14 @@ ensure_tool_symlinks() {
     local managed_names="${2:-}"
     local tool_label="${TOOL_LABEL[${tool_id}]}"
     local tool_skills_dir="${TOOL_SKILLS_DIR[${tool_id}]}"
+
+    # Skip tools that discover ~/.agents/skills/ natively.
+    local native
+    for native in "${TOOLS_NATIVE_DISCOVERY[@]}"; do
+        if [[ "${tool_id}" == "${native}" ]]; then
+            return
+        fi
+    done
 
     mkdir -p "${tool_skills_dir}"
 
@@ -167,6 +180,20 @@ TOOL_AVAILABLE=""
 check_tool_availability() {
     local tool_id="$1"
     local skill_name="$2"
+
+    # Tools with native discovery read ~/.agents/skills/ directly — no symlink needed.
+    local native
+    for native in "${TOOLS_NATIVE_DISCOVERY[@]}"; do
+        if [[ "${tool_id}" == "${native}" ]]; then
+            if [[ -f "${SKILLS_DIR}/${skill_name}/SKILL.md" ]]; then
+                TOOL_AVAILABLE="ok"
+            else
+                TOOL_AVAILABLE="partial"
+            fi
+            return
+        fi
+    done
+
     local tool_target="${TOOL_SKILLS_DIR[${tool_id}]}/${skill_name}"
 
     if [[ -L "${tool_target}" ]]; then

--- a/bin/sparkdock-agents-status
+++ b/bin/sparkdock-agents-status
@@ -179,7 +179,7 @@ render_table() {
 
 # --- Upstream cache ---
 
-log_section "Agent Resources Status"
+log_section "Skills & Agent Profiles"
 
 CACHE_AVAILABLE=false
 CONFLICTS_FOUND=false

--- a/bin/sparkdock-agents-sync
+++ b/bin/sparkdock-agents-sync
@@ -22,6 +22,11 @@ CACHE_DIR="${HOME}/.cache/sparkdock/agent-skills"
 MANIFEST_PATH="${HOME}/.cache/sparkdock/sf-skills-manifest.json"
 FORCE=false
 
+# Support SPARKDOCK_AGENTS_FORCE env var (used by Ansible integration)
+if [[ "${SPARKDOCK_AGENTS_FORCE:-}" == "true" ]]; then
+    FORCE=true
+fi
+
 # --- Skills configuration ---
 SKILLS_TARGET_DIR="${HOME}/.agents/skills"
 SYSTEM_SKILLS_SUBDIR="skills/system"

--- a/sjust/libs/libshell.sh
+++ b/sjust/libs/libshell.sh
@@ -14,17 +14,18 @@ export SPARKDOCK_ROOT
 # Render tab-separated data as a formatted table.
 # Reads TSV from stdin, outputs formatted table to stdout.
 # Uses gum table when available, falls back to column(1).
+# Note: gum table leaks \e[1m on the first data row; we strip it here.
 # Usage: render_table <<< "${tsv_data}"
 render_table() {
     local data
     data="$(cat)"
 
     if [[ "${HAS_GUM}" = true ]]; then
-        echo "${data}" | gum table --print \
+        printf '%s\n' "${data}" | gum table --print \
             --separator=$'\t' \
-            --border.foreground 240
+            --border.foreground 240 | sed $'s/\033\\[1m//g'
     else
-        echo "${data}" | column -t -s $'\t'
+        printf '%s\n' "${data}" | column -t -s $'\t'
     fi
 }
 

--- a/sjust/libs/libshell.sh
+++ b/sjust/libs/libshell.sh
@@ -11,6 +11,23 @@ source "$(dirname "${BASH_SOURCE[0]:-$0}")/../../bin/common/logging.sh"
 : "${SPARKDOCK_ROOT:=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../.." && pwd)}"
 export SPARKDOCK_ROOT
 
+# Render tab-separated data as a formatted table.
+# Reads TSV from stdin, outputs formatted table to stdout.
+# Uses gum table when available, falls back to column(1).
+# Usage: render_table <<< "${tsv_data}"
+render_table() {
+    local data
+    data="$(cat)"
+
+    if [[ "${HAS_GUM}" = true ]]; then
+        echo "${data}" | gum table --print \
+            --separator=$'\t' \
+            --border.foreground 240
+    else
+        echo "${data}" | column -t -s $'\t'
+    fi
+}
+
 # Check if a user file is symlinked to Sparkdock's default
 # Usage: check_sparkdock_symlink <user_file> <sparkdock_file>
 # Returns:

--- a/sjust/recipes/shared/01-ai-coding-agents.just
+++ b/sjust/recipes/shared/01-ai-coding-agents.just
@@ -1,9 +1,9 @@
 # vim: set ft=make :
 
-# Refresh AI coding agent resources (skills + agent profiles) from upstream.
+# Sync all AI coding agent resources: skills, agent profiles, RTK hooks, and caveman.
 # Pass "force" or "--force" to overwrite local modifications.
 [group('ai-coding-agents')]
-sf-agents-refresh $force="":
+sf-agents-sync $force="":
     #!/usr/bin/env bash
     set -euo pipefail
     if [[ "${force}" == "force" || "${force}" == "--force" ]]; then
@@ -11,11 +11,27 @@ sf-agents-refresh $force="":
     else
         {{sparkdock_path}}/bin/sparkdock-agents-sync
     fi
+    {{sparkdock_path}}/sjust/scripts/rtk/setup.sh
+    {{sparkdock_path}}/sjust/scripts/caveman/setup.sh install
 
-# Show status of AI coding agent resources (skills + agent profiles).
+# Backward-compatible alias for sf-agents-sync.
+[group('ai-coding-agents')]
+sf-agents-refresh $force="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "NOTE: sf-agents-refresh is deprecated, use sf-agents-sync instead." >&2
+    if [[ "${force}" == "force" || "${force}" == "--force" ]]; then
+        {{sparkdock_path}}/bin/sparkdock-agents-sync --force
+    else
+        {{sparkdock_path}}/bin/sparkdock-agents-sync
+    fi
+    {{sparkdock_path}}/sjust/scripts/rtk/setup.sh
+    {{sparkdock_path}}/sjust/scripts/caveman/setup.sh install
+
+# Show full AI agent harness status: token optimization tools, skills, and agent profiles.
 [group('ai-coding-agents')]
 sf-agents-status:
-    @{{sparkdock_path}}/bin/sparkdock-agents-status
+    @{{sparkdock_path}}/sjust/scripts/harness-status.sh
 
 # Check Copilot model context/output limits against the current opencode.json config.
 # Pass --update to automatically write the correct limits to opencode.json.

--- a/sjust/recipes/shared/01-ai-coding-agents.just
+++ b/sjust/recipes/shared/01-ai-coding-agents.just
@@ -1,6 +1,6 @@
 # vim: set ft=make :
 
-# Sync all AI coding agent resources: skills, agent profiles, RTK hooks, and caveman.
+# Sync AI coding agent skills and profiles from upstream (fast, no sudo).
 # Pass "force" or "--force" to overwrite local modifications.
 [group('ai-coding-agents')]
 sf-agents-sync $force="":
@@ -11,8 +11,20 @@ sf-agents-sync $force="":
     else
         {{sparkdock_path}}/bin/sparkdock-agents-sync
     fi
-    {{sparkdock_path}}/sjust/scripts/rtk/setup.sh
-    {{sparkdock_path}}/sjust/scripts/caveman/setup.sh install
+
+# Upgrade the full AI agent harness: brew formulae, skills, agent profiles,
+# RTK hooks, and caveman. Runs via Ansible (no sudo required).
+# Pass "force" or "--force" to overwrite locally modified resources.
+[group('ai-coding-agents')]
+sf-agents-upgrade $force="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ "${force}" == "force" || "${force}" == "--force" ]]; then
+        export SPARKDOCK_AGENTS_FORCE=true
+    fi
+    ansible-playbook -i "{{sparkdock_path}}/ansible/inventory.ini" \
+        "{{sparkdock_path}}/ansible/macos/macos/base.yml" \
+        -v --tags "ai-harness-sync"
 
 # Backward-compatible alias for sf-agents-sync.
 [group('ai-coding-agents')]
@@ -25,8 +37,6 @@ sf-agents-refresh $force="":
     else
         {{sparkdock_path}}/bin/sparkdock-agents-sync
     fi
-    {{sparkdock_path}}/sjust/scripts/rtk/setup.sh
-    {{sparkdock_path}}/sjust/scripts/caveman/setup.sh install
 
 # Show full AI agent harness status: token optimization tools, skills, and agent profiles.
 [group('ai-coding-agents')]

--- a/sjust/scripts/harness-status.sh
+++ b/sjust/scripts/harness-status.sh
@@ -6,8 +6,8 @@ set -euo pipefail
 # Displays a unified dashboard of installed harness tools (RTK, caveman, etc.),
 # their per-agent integration status, and token savings metrics.
 #
-# Extensible: to add a new tool, define _<tool>_version, _<tool>_active,
-# _<tool>_gain, _<tool>_agents functions and append to HARNESS_TOOLS.
+# Extensible: to add a new tool, define _<tool>_type, _<tool>_version,
+# _<tool>_active, _<tool>_gain, _<tool>_agents functions and append to HARNESS_TOOLS.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../libs/libshell.sh
@@ -98,10 +98,15 @@ _caveman_type() { echo "output"; }
 _caveman_version() {
     local caveman_dir="${HOME}/.cache/sparkdock/caveman"
     if [[ -d "${caveman_dir}/.git" ]]; then
-        git -C "${caveman_dir}" log -1 --format="%h" 2>/dev/null || echo ""
-    else
-        echo ""
+        git -C "${caveman_dir}" log -1 --format="%h" 2>/dev/null || echo "unknown"
+        return
     fi
+    # Caveman may be configured without the git cache present
+    if [[ -f "${HOME}/.config/caveman/config.json" ]]; then
+        echo "unknown"
+        return
+    fi
+    echo ""
 }
 
 _caveman_active() {
@@ -193,7 +198,7 @@ _render_tool_table() {
     done
 
     local rows=""
-    local any_installed=false
+    local any_present=false
 
     for tool in "${HARNESS_TOOLS[@]}"; do
         local version type status agent_cols
@@ -209,17 +214,18 @@ _render_tool_table() {
                 agent_cols+="${SEP}—"
             done
         else
+            any_present=true
             if "_${tool}_active"; then
                 status="✓ active"
-                any_installed=true
             else
                 status="✗ inactive"
             fi
 
-            local agent_values
-            agent_values="$("_${tool}_agents")"
+            local agent_values_str agent_arr
+            agent_values_str="$("_${tool}_agents")"
+            IFS=' ' read -ra agent_arr <<< "${agent_values_str}"
             agent_cols=""
-            for val in ${agent_values}; do
+            for val in "${agent_arr[@]}"; do
                 agent_cols+="${SEP}${val}"
             done
         fi
@@ -229,22 +235,23 @@ _render_tool_table() {
 
     local csv_data="${header}"$'\n'"${rows%$'\n'}"
 
-    if [[ "${HAS_GUM}" = true ]]; then
-        echo "${csv_data}" | gum table --print \
-            --separator=$'\t' \
-            --border.foreground 240 \
-            | perl -pe '
-                s/\e\[1m//g;
-                s/✓ active/\e[38;5;40m✓ active\e[0m/g;
-                s/✗ not installed/\e[2m✗ not installed\e[0m/g;
-                s/✗ inactive/\e[38;5;220m✗ inactive\e[0m/g;
-                s/\bok\b/\e[38;5;40mok\e[0m/g;
-            '
+    local table_output
+    table_output="$(render_table <<< "${csv_data}")"
+
+    # Colorize status markers
+    if command -v perl &>/dev/null; then
+        echo "${table_output}" | perl -pe '
+            s/\e\[1m//g;
+            s/✓ active/\e[38;5;40m✓ active\e[0m/g;
+            s/✗ not installed/\e[2m✗ not installed\e[0m/g;
+            s/✗ inactive/\e[38;5;220m✗ inactive\e[0m/g;
+            s/\bok\b/\e[38;5;40mok\e[0m/g;
+        '
     else
-        echo "${csv_data}" | column -t -s $'\t'
+        echo "${table_output}"
     fi
 
-    if [[ "${any_installed}" = false ]]; then
+    if [[ "${any_present}" = false ]]; then
         echo ""
         log_warn "No harness tools detected. Install with:"
         log_info "  RTK:     brew install rtk && sjust sf-rtk-setup"

--- a/sjust/scripts/harness-status.sh
+++ b/sjust/scripts/harness-status.sh
@@ -43,10 +43,15 @@ _rtk_gain() {
     local json
     json="$(rtk gain --format json 2>/dev/null)" || { echo "gain data unavailable"; return; }
 
+    if ! command -v python3 &>/dev/null; then
+        echo "gain data unavailable (python3 not found)"
+        return
+    fi
+
     local tokens_saved reduction_pct commands_count
-    tokens_saved="$(echo "${json}" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('tokens_saved', d.get('total_tokens_saved', 0)))" 2>/dev/null)" || tokens_saved="0"
-    reduction_pct="$(echo "${json}" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('reduction_pct', d.get('total_reduction_pct', 0)))" 2>/dev/null)" || reduction_pct="0"
-    commands_count="$(echo "${json}" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('commands_count', d.get('total_commands', 0)))" 2>/dev/null)" || commands_count="0"
+    tokens_saved="$(printf '%s' "${json}" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('tokens_saved', d.get('total_tokens_saved', 0)))" 2>/dev/null)" || tokens_saved="0"
+    reduction_pct="$(printf '%s' "${json}" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('reduction_pct', d.get('total_reduction_pct', 0)))" 2>/dev/null)" || reduction_pct="0"
+    commands_count="$(printf '%s' "${json}" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('commands_count', d.get('total_commands', 0)))" 2>/dev/null)" || commands_count="0"
 
     if [[ "${tokens_saved}" == "0" || -z "${tokens_saved}" ]]; then
         echo "No data yet — run some rtk commands to start tracking"
@@ -121,7 +126,11 @@ _caveman_gain() {
     fi
 
     local mode
-    mode="$(python3 -c "import json,sys; print(json.load(sys.stdin).get('defaultMode', 'unknown'))" < "${config}" 2>/dev/null)" || mode="unknown"
+    if command -v python3 &>/dev/null; then
+        mode="$(python3 -c "import json,sys; print(json.load(sys.stdin).get('defaultMode', 'unknown'))" < "${config}" 2>/dev/null)" || mode="unknown"
+    else
+        mode="unknown"
+    fi
 
     local estimate=""
     case "${mode}" in
@@ -240,15 +249,14 @@ _render_tool_table() {
 
     # Colorize status markers
     if command -v perl &>/dev/null; then
-        echo "${table_output}" | perl -pe '
-            s/\e\[1m//g;
+        printf '%s\n' "${table_output}" | perl -pe '
             s/✓ active/\e[38;5;40m✓ active\e[0m/g;
             s/✗ not installed/\e[2m✗ not installed\e[0m/g;
             s/✗ inactive/\e[38;5;220m✗ inactive\e[0m/g;
             s/\bok\b/\e[38;5;40mok\e[0m/g;
         '
     else
-        echo "${table_output}"
+        printf '%s\n' "${table_output}"
     fi
 
     if [[ "${any_present}" = false ]]; then

--- a/sjust/scripts/harness-status.sh
+++ b/sjust/scripts/harness-status.sh
@@ -116,7 +116,7 @@ _caveman_gain() {
     fi
 
     local mode
-    mode="$(python3 -c "import json; print(json.load(open('${config}')).get('defaultMode', 'unknown'))" 2>/dev/null)" || mode="unknown"
+    mode="$(python3 -c "import json,sys; print(json.load(sys.stdin).get('defaultMode', 'unknown'))" < "${config}" 2>/dev/null)" || mode="unknown"
 
     local estimate=""
     case "${mode}" in
@@ -196,10 +196,10 @@ _render_tool_table() {
     local any_installed=false
 
     for tool in "${HARNESS_TOOLS[@]}"; do
-        local version layer status agent_cols
+        local version type status agent_cols
 
         version="$("_${tool}_version")"
-        layer="$("_${tool}_type")"
+        type="$("_${tool}_type")"
 
         if [[ -z "${version}" ]]; then
             status="✗ not installed"
@@ -224,7 +224,7 @@ _render_tool_table() {
             done
         fi
 
-        rows+="${tool}${SEP}${layer}${SEP}${version}${SEP}${status}${agent_cols}"$'\n'
+        rows+="${tool}${SEP}${type}${SEP}${version}${SEP}${status}${agent_cols}"$'\n'
     done
 
     local csv_data="${header}"$'\n'"${rows%$'\n'}"

--- a/sjust/scripts/harness-status.sh
+++ b/sjust/scripts/harness-status.sh
@@ -1,0 +1,307 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# sjust/scripts/harness-status.sh — Show status of AI agent token harness tools.
+#
+# Displays a unified dashboard of installed harness tools (RTK, caveman, etc.),
+# their per-agent integration status, and token savings metrics.
+#
+# Extensible: to add a new tool, define _<tool>_version, _<tool>_active,
+# _<tool>_gain, _<tool>_agents functions and append to HARNESS_TOOLS.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../libs/libshell.sh
+source "${SCRIPT_DIR}/../libs/libshell.sh"
+
+# --- Registry ---
+
+HARNESS_TOOLS=(rtk caveman)
+AGENTS=(claude copilot opencode)
+
+# --- RTK functions ---
+
+_rtk_type() { echo "input"; }
+
+_rtk_version() {
+    if command -v rtk &>/dev/null; then
+        rtk --version 2>/dev/null | awk '{print $2}'
+    else
+        echo ""
+    fi
+}
+
+_rtk_active() {
+    command -v rtk &>/dev/null
+}
+
+_rtk_gain() {
+    if ! command -v rtk &>/dev/null; then
+        echo "not installed"
+        return
+    fi
+
+    local json
+    json="$(rtk gain --format json 2>/dev/null)" || { echo "gain data unavailable"; return; }
+
+    local tokens_saved reduction_pct commands_count
+    tokens_saved="$(echo "${json}" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('tokens_saved', d.get('total_tokens_saved', 0)))" 2>/dev/null)" || tokens_saved="0"
+    reduction_pct="$(echo "${json}" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('reduction_pct', d.get('total_reduction_pct', 0)))" 2>/dev/null)" || reduction_pct="0"
+    commands_count="$(echo "${json}" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('commands_count', d.get('total_commands', 0)))" 2>/dev/null)" || commands_count="0"
+
+    if [[ "${tokens_saved}" == "0" || -z "${tokens_saved}" ]]; then
+        echo "No data yet — run some rtk commands to start tracking"
+        return
+    fi
+
+    printf "Tokens saved: %s  │  Reduction: %s%%  │  Commands: %s" \
+        "${tokens_saved}" "${reduction_pct}" "${commands_count}"
+}
+
+_rtk_agents() {
+    local -A result=()
+    result[claude]="—"
+    result[copilot]="—"
+    result[opencode]="—"
+
+    # Claude: check for rtk hook in settings.json
+    local claude_settings="${HOME}/.claude/settings.json"
+    if [[ -f "${claude_settings}" ]] && grep -q "rtk" "${claude_settings}" 2>/dev/null; then
+        result[claude]="ok"
+    fi
+
+    # Copilot: check for RTK MANAGED BLOCK in instructions
+    local copilot_instructions="${HOME}/.copilot/copilot-instructions.md"
+    if [[ -f "${copilot_instructions}" ]] && grep -q "RTK MANAGED BLOCK" "${copilot_instructions}" 2>/dev/null; then
+        result[copilot]="ok"
+    fi
+
+    # OpenCode: check for rtk plugin or RTK MANAGED BLOCK in AGENTS.md
+    local opencode_plugin="${HOME}/.config/opencode/plugins/rtk.ts"
+    local opencode_agents="${HOME}/.config/opencode/AGENTS.md"
+    if [[ -f "${opencode_plugin}" ]] || \
+       { [[ -f "${opencode_agents}" ]] && grep -q "RTK MANAGED BLOCK" "${opencode_agents}" 2>/dev/null; }; then
+        result[opencode]="ok"
+    fi
+
+    # Print space-separated values in AGENTS order
+    local out=""
+    for agent in "${AGENTS[@]}"; do
+        out+="${result[${agent}]} "
+    done
+    echo "${out% }"
+}
+
+# --- Caveman functions ---
+
+_caveman_type() { echo "output"; }
+
+_caveman_version() {
+    local caveman_dir="${HOME}/.cache/sparkdock/caveman"
+    if [[ -d "${caveman_dir}/.git" ]]; then
+        git -C "${caveman_dir}" log -1 --format="%h" 2>/dev/null || echo ""
+    else
+        echo ""
+    fi
+}
+
+_caveman_active() {
+    [[ -f "${HOME}/.config/caveman/config.json" ]]
+}
+
+_caveman_gain() {
+    local config="${HOME}/.config/caveman/config.json"
+    if [[ ! -f "${config}" ]]; then
+        echo "not configured"
+        return
+    fi
+
+    local mode
+    mode="$(python3 -c "import json; print(json.load(open('${config}')).get('defaultMode', 'unknown'))" 2>/dev/null)" || mode="unknown"
+
+    local estimate=""
+    case "${mode}" in
+        lite)  estimate="~25%" ;;
+        full)  estimate="~50%" ;;
+        ultra) estimate="~75%" ;;
+        *)     estimate="unknown" ;;
+    esac
+
+    printf "Mode: %s  │  Est. output reduction: %s  │  (session-level only)" \
+        "${mode}" "${estimate}"
+}
+
+_caveman_agents() {
+    local -A result=()
+    result[claude]="—"
+    result[copilot]="—"
+    result[opencode]="—"
+
+    # Claude: check for caveman hook in settings.json
+    local claude_settings="${HOME}/.claude/settings.json"
+    if [[ -f "${claude_settings}" ]] && grep -q "caveman" "${claude_settings}" 2>/dev/null; then
+        result[claude]="ok"
+    fi
+
+    # Copilot: check for CAVEMAN MANAGED BLOCK or caveman-begin in instructions
+    local copilot_instructions="${HOME}/.copilot/copilot-instructions.md"
+    if [[ -f "${copilot_instructions}" ]] && \
+       grep -q "CAVEMAN MANAGED BLOCK\|caveman-begin" "${copilot_instructions}" 2>/dev/null; then
+        result[copilot]="ok"
+    fi
+
+    # OpenCode: check for caveman plugin directory
+    local opencode_plugin_dir="${HOME}/.config/opencode/plugins/caveman"
+    if [[ -d "${opencode_plugin_dir}" ]]; then
+        result[opencode]="ok"
+    fi
+
+    # Print space-separated values in AGENTS order
+    local out=""
+    for agent in "${AGENTS[@]}"; do
+        out+="${result[${agent}]} "
+    done
+    echo "${out% }"
+}
+
+# --- Output formatting ---
+
+_print_header() {
+    local title="AI Agent Harness — Token Optimization Stack"
+    if [[ "${HAS_GUM}" = true ]]; then
+        echo ""
+        gum style --border double --border-foreground 99 --bold --padding "0 2" --margin "0 0 1 0" "${title}"
+    else
+        echo ""
+        printf "${BOLD}${BLUE}=== %s ===${NC}\n\n" "${title}"
+    fi
+}
+
+_print_section() {
+    local title="$1"
+    if [[ "${HAS_GUM}" = true ]]; then
+        gum style --bold --foreground 99 "${title}"
+    else
+        printf "\n${BOLD}%s${NC}\n" "${title}"
+    fi
+}
+
+_render_tool_table() {
+    local SEP=$'\t'
+    local header="TOOL${SEP}TYPE${SEP}VERSION${SEP}STATUS"
+    for agent in "${AGENTS[@]}"; do
+        header+="${SEP}$(echo "${agent}" | tr '[:lower:]' '[:upper:]')"
+    done
+
+    local rows=""
+    local any_installed=false
+
+    for tool in "${HARNESS_TOOLS[@]}"; do
+        local version layer status agent_cols
+
+        version="$("_${tool}_version")"
+        layer="$("_${tool}_type")"
+
+        if [[ -z "${version}" ]]; then
+            status="✗ not installed"
+            version="—"
+            agent_cols=""
+            for _ in "${AGENTS[@]}"; do
+                agent_cols+="${SEP}—"
+            done
+        else
+            if "_${tool}_active"; then
+                status="✓ active"
+                any_installed=true
+            else
+                status="✗ inactive"
+            fi
+
+            local agent_values
+            agent_values="$("_${tool}_agents")"
+            agent_cols=""
+            for val in ${agent_values}; do
+                agent_cols+="${SEP}${val}"
+            done
+        fi
+
+        rows+="${tool}${SEP}${layer}${SEP}${version}${SEP}${status}${agent_cols}"$'\n'
+    done
+
+    local csv_data="${header}"$'\n'"${rows%$'\n'}"
+
+    if [[ "${HAS_GUM}" = true ]]; then
+        echo "${csv_data}" | gum table --print \
+            --separator=$'\t' \
+            --border.foreground 240 \
+            | perl -pe '
+                s/\e\[1m//g;
+                s/✓ active/\e[38;5;40m✓ active\e[0m/g;
+                s/✗ not installed/\e[2m✗ not installed\e[0m/g;
+                s/✗ inactive/\e[38;5;220m✗ inactive\e[0m/g;
+                s/\bok\b/\e[38;5;40mok\e[0m/g;
+            '
+    else
+        echo "${csv_data}" | column -t -s $'\t'
+    fi
+
+    if [[ "${any_installed}" = false ]]; then
+        echo ""
+        log_warn "No harness tools detected. Install with:"
+        log_info "  RTK:     brew install rtk && sjust sf-rtk-setup"
+        log_info "  Caveman: sjust sf-caveman-install"
+        return 1
+    fi
+    return 0
+}
+
+_render_gain_section() {
+    _print_section "Token Savings"
+    echo ""
+
+    for tool in "${HARNESS_TOOLS[@]}"; do
+        local version
+        version="$("_${tool}_version")"
+        [[ -z "${version}" ]] && continue
+
+        local gain
+        gain="$("_${tool}_gain")"
+        printf "  %s: %s\n" "${tool}" "${gain}"
+    done
+}
+
+_render_commands_section() {
+    _print_section "Deep Dive Commands"
+    echo ""
+
+    local dim='' reset=''
+    if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
+        dim=$'\033[2m'
+        reset=$'\033[0m'
+    fi
+
+    if command -v rtk &>/dev/null; then
+        printf "  %srtk gain%s              Input savings breakdown\n" "${dim}" "${reset}"
+        printf "  %srtk gain --graph%s      Daily savings chart\n" "${dim}" "${reset}"
+    fi
+    printf "  %s/caveman-stats%s        In-session output stats\n" "${dim}" "${reset}"
+    echo ""
+}
+
+# --- Main ---
+
+main() {
+    _print_header
+    if _render_tool_table; then
+        _render_gain_section
+        echo ""
+        _render_commands_section
+    fi
+
+    # Show skills + agent profiles (the other half of the harness)
+    local agents_status="${SCRIPT_DIR}/../../bin/sparkdock-agents-status"
+    if [[ -x "${agents_status}" ]]; then
+        "${agents_status}"
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

Adds a unified `sf-agents-status` dashboard showing the full AI agent harness: token optimization tools (RTK, caveman), skills, and agent profiles — with per-agent integration columns for Claude, Copilot, and OpenCode.

Consolidates AI agent commands into two primary entry points:
- `sf-agents-status` — show everything
- `sf-agents-sync` — update everything (skills, agents, RTK hooks, caveman)

## Changes

### New: Unified harness status dashboard (`sjust/scripts/harness-status.sh`)
- Registry-based architecture: 4 functions + 1 array entry per tool (`_type`, `_version`, `_active`, `_gain`, `_agents`)
- RTK: version detection, hook integration check per agent, token savings from `rtk gain --format json`
- Caveman: git commit version, config detection, mode/estimated reduction display
- Per-agent columns (CLAUDE, COPILOT, OPENCODE) showing integration status
- Gum table rendering with ANSI colorization (perl-gated, graceful fallback)
- Token savings section + deep dive commands reference
- Calls `sparkdock-agents-status` for the skills/profiles half

### New: OpenCode column in skills table
- Added opencode to `TOOL_SKILLS_DIR` registry with native discovery support
- OpenCode reads `~/.agents/skills/` directly (no symlinks needed)
- `check_tool_availability` short-circuits for native-discovery tools
- `ensure_tool_symlinks` skips native-discovery tools (avoids duplicates)

### Renamed commands
- `sf-agents-status` now runs the unified harness dashboard (was: just `sparkdock-agents-status`)
- `sf-agents-sync` runs full pipeline: agents-sync + RTK setup + caveman install
- `sf-agents-refresh` kept as backward-compat alias with deprecation notice

### Section title rename
- "Agent Resources Status" → "Skills & Agent Profiles" (clearer in unified context)

### Generic `render_table` utility (`sjust/libs/libshell.sh`)
- Extracted reusable TSV → table renderer (gum table with column(1) fallback)
- Domain-specific colorization stays in callers

### Ansible: formulae upgrade policy
- Homebrew formulae: `state: latest` (CLI tools upgrade on every provision)
- Casks: `state: present` (GUI apps only installed, not force-upgraded)

## Example output

```
╔═══════════════════════════════════════════════╗
║  AI Agent Harness — Token Optimization Stack  ║
╚═══════════════════════════════════════════════╝

┌─────────┬────────┬─────────┬──────────┬────────┬─────────┬──────────┐
│ TOOL    │ TYPE   │ VERSION │ STATUS   │ CLAUDE │ COPILOT │ OPENCODE │
├─────────┼────────┼─────────┼──────────┼────────┼─────────┼──────────┤
│ rtk     │ input  │ 0.39.0  │ ✓ active │ ok     │ ok      │ ok       │
│ caveman │ output │ 655b7d9 │ ✓ active │ ok     │ ok      │ ok       │
└─────────┴────────┴─────────┴──────────┴────────┴─────────┴──────────┘

Token Savings
  rtk: Tokens saved: 12345  │  Reduction: 42%  │  Commands: 89
  caveman: Mode: full  │  Est. output reduction: ~50%  │  (session-level only)

╔═══════════════════════════╗
║  Skills & Agent Profiles  ║
╚═══════════════════════════╝

Skills
┌────────────────────────┬─────────┬────────────┬─────────────────────────┬────────┬─────────┬──────────┐
│ NAME                   │ TYPE    │ STATUS     │ DESCRIPTION             │ CLAUDE │ COPILOT │ OPENCODE │
├────────────────────────┼─────────┼────────────┼─────────────────────────┼────────┼─────────┼──────────┤
│ glab                   │ managed │ up to date │ GitLab CLI (issues,...) │ ok     │ ok      │ ok       │
│ ...                    │         │            │                         │        │         │          │
└────────────────────────┴─────────┴────────────┴─────────────────────────┴────────┴─────────┴──────────┘
```

## Refs

Closes sparkfabrik/sparkdock#472