### PR TITLE
refactor(harness): rename ai-coding-agents to ai-coding-harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,14 +255,19 @@ Located at `~/.cache/sparkdock/sf-skills-manifest.json`. V2 format with `skills`
 
 The upstream repo provides `config/catalog.json` with short human-friendly descriptions for each system skill and agent. The status script reads this file from the local cache (`~/.cache/sparkdock/agent-skills/config/catalog.json`) to display a DESCRIPTION column in the table. No sync changes are needed — the file is part of the cloned cache.
 
-### sjust Recipes (`sjust/recipes/05-ai-coding-agents.just`)
+### sjust Recipes (`sjust/recipes/shared/01-ai-coding-harness.just`)
 
-- `sf-agents-refresh [force]` — Sync all resources (skills + agents)
-- `sf-agents-status` — Show status of all resources
+- `sf-harness-status` — Show full AI coding harness status (tools + skills + profiles)
+- `sf-harness-sync [force]` — Fast sync: skills + agent profiles from upstream
+- `sf-harness-upgrade [force]` — Full upgrade via Ansible (RTK + caveman + skills)
 
 ### Ansible Tags
 
-- `ai-coding-agents` (new) and `skills` (kept for backward compat)
+- `ai-coding-harness` — umbrella tag for AI coding harness tasks
+- `ai-harness` — alternate umbrella (includes sync + provision)
+- `ai-harness-sync` — no-sudo tasks (RTK + caveman + skills sync)
+- `ai-harness-provision` — sudo tasks (directory creation + chmod)
+- `skills` — backward-compat alias
 
 ### OpenSpec Change
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,18 @@ my-recipe $param="default":
 
 Without the `$` prefix, parameters require `{{param}}` interpolation in recipe lines.
 
+**Deprecated Command Aliases:**
+
+When renaming commands, use `[private] alias` to route old names to new ones without body duplication. Private aliases are hidden from `--list` but still callable:
+
+```just
+# Deprecated aliases (hidden from --list, silently route to new names)
+[private]
+alias old-name := new-name
+```
+
+This avoids tech debt from duplicated recipe bodies. Old names work silently — users discover new names naturally from `sjust --list`. Never duplicate full recipe bodies for backward compatibility; always use this pattern instead.
+
 ### HTTP Proxy Management
 
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Renamed sjust group `ai-coding-agents` → `ai-coding-harness` and commands `sf-agents-status` → `sf-harness-status`, `sf-agents-sync` → `sf-harness-sync`, `sf-agents-upgrade` → `sf-harness-upgrade`; old names kept as deprecated aliases with notice. Recipe file renamed `01-ai-coding-agents.just` → `01-ai-coding-harness.just`. Ansible tag updated to `ai-coding-harness` (keeping `skills` for backward compat)
 - Copilot custom instructions now write only to `~/.copilot/copilot-instructions.md` (official Copilot CLI local instructions path per GitHub docs); dropped undocumented `~/.github/copilot-instructions.md`. Applies to both RTK and caveman setup scripts. Existing orphaned blocks in `~/.github/copilot-instructions.md` are cleaned up automatically on next run
 - Simplified Copilot RTK helper instructions to focus on `rtk-run`, concise command examples, quoted shell operators, and raw-command fallback
 - Reworked RTK setup to support Claude Code (global hook), OpenCode (plugin), and Copilot (helper + instructions with `rtk-run` for high-output local commands, but raw commands for destructive, infrastructure, and remote-state actions) while preserving RTK's base config and always rewriting Sparkdock-managed `exclude_commands`

--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -925,10 +925,10 @@
           changed_when: true
           become: false
 
-    - name: Provision AI coding agent directories and permissions
+    - name: Provision AI coding harness directories and permissions
       tags:
         - skills
-        - ai-coding-agents
+        - ai-coding-harness
         - ai-harness
         - ai-harness-provision
       block:
@@ -988,10 +988,10 @@
           become: yes
           become_method: sudo
 
-    - name: Sync AI coding agent resources from upstream repository
+    - name: Sync AI coding harness resources from upstream repository
       tags:
         - skills
-        - ai-coding-agents
+        - ai-coding-harness
         - ai-harness
         - ai-harness-sync
       block:

--- a/bin/common/skills-symlink-shim.sh
+++ b/bin/common/skills-symlink-shim.sh
@@ -243,7 +243,7 @@ print_tool_issues() {
         lines+=("  • ${issue}")
     done
     lines+=("")
-    lines+=("Run 'sjust sf-agents-refresh force' to fix.")
+    lines+=("Run 'sjust sf-harness-sync force' to fix.")
 
     local body
     body="$(printf '%s\n' "${lines[@]}")"

--- a/bin/sparkdock-agents-status
+++ b/bin/sparkdock-agents-status
@@ -391,20 +391,20 @@ echo ""
 if [[ -f "${MANIFEST_PATH}" ]]; then
     print_faint "Manifest: ${MANIFEST_PATH}"
 else
-    log_warn "No manifest found. Run 'sjust sf-agents-refresh' to sync."
+    log_warn "No manifest found. Run 'sjust sf-harness-sync' to sync."
 fi
 if [[ "${CACHE_AVAILABLE}" == "false" ]]; then
-    log_warn "No upstream cache found. Run 'sjust sf-agents-refresh' to enable update checks."
+    log_warn "No upstream cache found. Run 'sjust sf-harness-sync' to enable update checks."
 fi
 if [[ "${CONFLICTS_FOUND}" == "true" ]]; then
-    log_warn "Some user resources conflict with upstream. Run 'sjust sf-agents-refresh force' to overwrite."
+    log_warn "Some user resources conflict with upstream. Run 'sjust sf-harness-sync force' to overwrite."
 fi
 if [[ "${ORPHANS_FOUND}" == "true" ]]; then
-    log_warn "Orphaned resources detected (removed from upstream). Run 'sjust sf-agents-refresh' to clean up."
+    log_warn "Orphaned resources detected (removed from upstream). Run 'sjust sf-harness-sync' to clean up."
 fi
 if [[ "${UPDATES_AVAILABLE}" == "true" ]]; then
-    log_warn "Updates available. Run 'sjust sf-agents-refresh' to update."
+    log_warn "Updates available. Run 'sjust sf-harness-sync' to update."
 fi
 if [[ "${NEW_RESOURCES_AVAILABLE}" == "true" ]]; then
-    log_warn "New resources available. Run 'sjust sf-agents-refresh' to install."
+    log_warn "New resources available. Run 'sjust sf-harness-sync' to install."
 fi

--- a/sjust/recipes/04-shared.just
+++ b/sjust/recipes/04-shared.just
@@ -1,7 +1,7 @@
 # vim: set ft=make :
 
 # Shared recipes - reusable across Justfiles.
-import "shared/01-ai-coding-agents.just"
+import "shared/01-ai-coding-harness.just"
 import "shared/02-githuman.just"
 import "shared/03-openspec.just"
 import "shared/04-format.just"

--- a/sjust/recipes/shared/01-ai-coding-harness.just
+++ b/sjust/recipes/shared/01-ai-coding-harness.just
@@ -31,49 +31,15 @@ sf-harness-upgrade $force="":
 sf-harness-status:
     @{{sparkdock_path}}/sjust/scripts/harness-status.sh
 
-# Deprecated: use sf-harness-sync instead.
-[group('ai-coding-harness')]
-sf-agents-sync $force="":
-    #!/usr/bin/env bash
-    set -euo pipefail
-    echo "NOTE: sf-agents-sync is deprecated, use sf-harness-sync instead." >&2
-    if [[ "${force}" == "force" || "${force}" == "--force" ]]; then
-        {{sparkdock_path}}/bin/sparkdock-agents-sync --force
-    else
-        {{sparkdock_path}}/bin/sparkdock-agents-sync
-    fi
-
-# Deprecated: use sf-harness-upgrade instead.
-[group('ai-coding-harness')]
-sf-agents-upgrade $force="":
-    #!/usr/bin/env bash
-    set -euo pipefail
-    echo "NOTE: sf-agents-upgrade is deprecated, use sf-harness-upgrade instead." >&2
-    if [[ "${force}" == "force" || "${force}" == "--force" ]]; then
-        export SPARKDOCK_AGENTS_FORCE=true
-    fi
-    ansible-playbook -i "{{sparkdock_path}}/ansible/inventory.ini" \
-        "{{sparkdock_path}}/ansible/macos/macos/base.yml" \
-        -v --tags "ai-harness-sync"
-
-# Deprecated: use sf-harness-status instead.
-[group('ai-coding-harness')]
-sf-agents-status:
-    #!/usr/bin/env bash
-    echo "NOTE: sf-agents-status is deprecated, use sf-harness-status instead." >&2
-    {{sparkdock_path}}/sjust/scripts/harness-status.sh
-
-# Deprecated: use sf-harness-sync instead.
-[group('ai-coding-harness')]
-sf-agents-refresh $force="":
-    #!/usr/bin/env bash
-    set -euo pipefail
-    echo "NOTE: sf-agents-refresh is deprecated, use sf-harness-sync instead." >&2
-    if [[ "${force}" == "force" || "${force}" == "--force" ]]; then
-        {{sparkdock_path}}/bin/sparkdock-agents-sync --force
-    else
-        {{sparkdock_path}}/bin/sparkdock-agents-sync
-    fi
+# Deprecated aliases (hidden from --list, silently route to new names)
+[private]
+alias sf-agents-sync := sf-harness-sync
+[private]
+alias sf-agents-upgrade := sf-harness-upgrade
+[private]
+alias sf-agents-status := sf-harness-status
+[private]
+alias sf-agents-refresh := sf-harness-sync
 
 # Check Copilot model context/output limits against the current opencode.json config.
 # Pass --update to automatically write the correct limits to opencode.json.

--- a/sjust/recipes/shared/01-ai-coding-harness.just
+++ b/sjust/recipes/shared/01-ai-coding-harness.just
@@ -1,9 +1,9 @@
 # vim: set ft=make :
 
-# Sync AI coding agent skills and profiles from upstream (fast, no sudo).
+# Sync AI coding harness skills and profiles from upstream (fast, no sudo).
 # Pass "force" or "--force" to overwrite local modifications.
-[group('ai-coding-agents')]
-sf-agents-sync $force="":
+[group('ai-coding-harness')]
+sf-harness-sync $force="":
     #!/usr/bin/env bash
     set -euo pipefail
     if [[ "${force}" == "force" || "${force}" == "--force" ]]; then
@@ -12,11 +12,11 @@ sf-agents-sync $force="":
         {{sparkdock_path}}/bin/sparkdock-agents-sync
     fi
 
-# Upgrade the full AI agent harness: brew formulae, skills, agent profiles,
+# Upgrade the full AI coding harness: brew formulae, skills, agent profiles,
 # RTK hooks, and caveman. Runs via Ansible (no sudo required).
 # Pass "force" or "--force" to overwrite locally modified resources.
-[group('ai-coding-agents')]
-sf-agents-upgrade $force="":
+[group('ai-coding-harness')]
+sf-harness-upgrade $force="":
     #!/usr/bin/env bash
     set -euo pipefail
     if [[ "${force}" == "force" || "${force}" == "--force" ]]; then
@@ -26,29 +26,61 @@ sf-agents-upgrade $force="":
         "{{sparkdock_path}}/ansible/macos/macos/base.yml" \
         -v --tags "ai-harness-sync"
 
-# Backward-compatible alias for sf-agents-sync.
-[group('ai-coding-agents')]
-sf-agents-refresh $force="":
+# Show full AI coding harness status: token optimization tools, skills, and agent profiles.
+[group('ai-coding-harness')]
+sf-harness-status:
+    @{{sparkdock_path}}/sjust/scripts/harness-status.sh
+
+# Deprecated: use sf-harness-sync instead.
+[group('ai-coding-harness')]
+sf-agents-sync $force="":
     #!/usr/bin/env bash
     set -euo pipefail
-    echo "NOTE: sf-agents-refresh is deprecated, use sf-agents-sync instead." >&2
+    echo "NOTE: sf-agents-sync is deprecated, use sf-harness-sync instead." >&2
     if [[ "${force}" == "force" || "${force}" == "--force" ]]; then
         {{sparkdock_path}}/bin/sparkdock-agents-sync --force
     else
         {{sparkdock_path}}/bin/sparkdock-agents-sync
     fi
 
-# Show full AI agent harness status: token optimization tools, skills, and agent profiles.
-[group('ai-coding-agents')]
+# Deprecated: use sf-harness-upgrade instead.
+[group('ai-coding-harness')]
+sf-agents-upgrade $force="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "NOTE: sf-agents-upgrade is deprecated, use sf-harness-upgrade instead." >&2
+    if [[ "${force}" == "force" || "${force}" == "--force" ]]; then
+        export SPARKDOCK_AGENTS_FORCE=true
+    fi
+    ansible-playbook -i "{{sparkdock_path}}/ansible/inventory.ini" \
+        "{{sparkdock_path}}/ansible/macos/macos/base.yml" \
+        -v --tags "ai-harness-sync"
+
+# Deprecated: use sf-harness-status instead.
+[group('ai-coding-harness')]
 sf-agents-status:
-    @{{sparkdock_path}}/sjust/scripts/harness-status.sh
+    #!/usr/bin/env bash
+    echo "NOTE: sf-agents-status is deprecated, use sf-harness-status instead." >&2
+    {{sparkdock_path}}/sjust/scripts/harness-status.sh
+
+# Deprecated: use sf-harness-sync instead.
+[group('ai-coding-harness')]
+sf-agents-refresh $force="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "NOTE: sf-agents-refresh is deprecated, use sf-harness-sync instead." >&2
+    if [[ "${force}" == "force" || "${force}" == "--force" ]]; then
+        {{sparkdock_path}}/bin/sparkdock-agents-sync --force
+    else
+        {{sparkdock_path}}/bin/sparkdock-agents-sync
+    fi
 
 # Check Copilot model context/output limits against the current opencode.json config.
 # Pass --update to automatically write the correct limits to opencode.json.
 # Requires GitHub Copilot authentication (gh CLI or OpenCode).
 # Refs: https://github.com/anomalyco/models.dev/issues/1136
 #       https://github.com/anomalyco/opencode/issues/16129
-[group('ai-coding-agents')]
+[group('ai-coding-harness')]
 sf-copilot-model-limits *args='':
     #!/usr/bin/env bash
     set -euo pipefail
@@ -60,7 +92,7 @@ sf-copilot-model-limits *args='':
 
 # List available Copilot model IDs (one per line). Useful for scripting with machine names.
 # Requires GitHub Copilot authentication (gh CLI or OpenCode).
-[group('ai-coding-agents')]
+[group('ai-coding-harness')]
 sf-copilot-model-list:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -73,7 +105,7 @@ sf-copilot-model-list:
 # Show current personal GitHub Copilot premium request usage.
 # Pass --json to output the raw API response for scripting.
 # Requires GitHub Copilot authentication (gh CLI or OpenCode).
-[group('ai-coding-agents')]
+[group('ai-coding-harness')]
 sf-copilot-premium-usage *args='':
     #!/usr/bin/env bash
     set -euo pipefail
@@ -86,11 +118,11 @@ sf-copilot-premium-usage *args='':
 # Install/update caveman output compression for Claude Code, OpenCode, and Copilot.
 # Clones (or updates) the caveman repo, writes default config, then installs
 # hooks/plugins/skills per agent. Safe to re-run — always deploys latest.
-[group('ai-coding-agents')]
+[group('ai-coding-harness')]
 sf-caveman-install:
     @{{sparkdock_path}}/sjust/scripts/caveman/setup.sh install
 
 # Remove caveman from all AI coding tools.
-[group('ai-coding-agents')]
+[group('ai-coding-harness')]
 sf-caveman-uninstall:
     @{{sparkdock_path}}/sjust/scripts/caveman/setup.sh uninstall

--- a/sjust/recipes/shared/03-openspec.just
+++ b/sjust/recipes/shared/03-openspec.just
@@ -2,6 +2,6 @@
 
 # Configure OpenSpec with custom profile and all workflows.
 # Pass 'force' to overwrite existing config without prompting.
-[group('ai-coding-agents')]
+[group('ai-coding-harness')]
 sf-openspec-configure $force="":
     {{sparkdock_path}}/sjust/scripts/openspec/configure.sh "${force}"

--- a/sjust/recipes/shared/05-rtk.just
+++ b/sjust/recipes/shared/05-rtk.just
@@ -2,6 +2,6 @@
 
 # Setup RTK (Rust Token Killer) for Claude Code, GitHub Copilot, and OpenCode.
 # Installs hooks, instructions, and rewrites Sparkdock-managed exclude_commands.
-[group('ai-coding-agents')]
+[group('ai-coding-harness')]
 sf-rtk-setup:
     {{sparkdock_path}}/sjust/scripts/rtk/setup.sh

--- a/src/menubar-app/Sources/SparkdockManager/main.swift
+++ b/src/menubar-app/Sources/SparkdockManager/main.swift
@@ -934,7 +934,7 @@ class SparkdockMenubarApp: NSObject, NSApplicationDelegate {
         // Allow refresh when agent resources have updates OR are not configured (initial setup)
         let agentsConfigured = isAgentsConfigured()
         guard hasAgentUpdates || !agentsConfigured else { return }
-        executeTerminalCommand("sjust sf-agents-refresh", recheckNotification: RecheckNotification.agents)
+        executeTerminalCommand("sjust sf-harness-sync", recheckNotification: RecheckNotification.agents)
     }
 
 


### PR DESCRIPTION
Renames sjust group ai-coding-agents to ai-coding-harness and commands sf-agents-* to sf-harness-*. Old names kept as deprecated aliases. Closes #474