### PR TITLE
feat: add pre-commit to homebrew packages

### DIFF
--- a/config/packages/all-packages.yml
+++ b/config/packages/all-packages.yml
@@ -83,6 +83,7 @@ homebrew_packages:
   - "php@8.2"
   - golang
   - gitleaks
+  - pre-commit
   - uv
   - llm
   - anomalyco/tap/opencode


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

Adds `pre-commit` to the Homebrew packages list so it's provisioned on all developer workstations.

## Why

The new `pkg_python` infrastructure package scaffolds `.pre-commit-config.yaml` to Python projects with ruff and uv hooks. While those hooks are self-contained (they download their own binaries), developers still need the `pre-commit` CLI on the host to activate hooks via `pre-commit install`.

Installing via Homebrew is consistent with how we already provision `uv`, `ruff`, and other dev tools.

Closes #476