### PR TITLE
fix(ansible): unhardcode python interpreter and dev_env_dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `sf-harness-upgrade` failing on non-macOS hosts (e.g. ajust on Arch Linux) with `module interpreter '/opt/homebrew/bin/python3' was not found` — `ansible/inventory.ini` now uses `ansible_python_interpreter=auto_silent` so Ansible discovers a working Python on any host, and `sf-harness-upgrade` passes `-e dev_env_dir={{sparkdock_path}}` so the playbook tracks the real sparkdock location instead of the hardcoded `/opt/sparkdock`. Same Ansible flow on macOS and Linux.
 - Fixed caveman OpenCode plugin hooks never firing — upstream uses non-existent `session.created` and `tui.prompt.append` hooks; patched to use `chat.message` + `experimental.chat.system.transform` ([caveman#418](https://github.com/JuliusBrussee/caveman/issues/418))
 - Added a "done" banner to the GitHub Copilot section of `sf-caveman-install` mirroring the native installer output for Claude Code and OpenCode, so the Copilot install step has matching visual weight instead of finishing on a single log line
 - Improved `sf-caveman-install` log message when Copilot instructions file is a symlink — now reports whether the symlink target already contains caveman rules instead of a misleading "skipping (managed externally)" message

--- a/ansible/inventory.ini
+++ b/ansible/inventory.ini
@@ -1,2 +1,2 @@
 [local]
-localhost ansible_connection=local ansible_python_interpreter=/opt/homebrew/bin/python3
+localhost ansible_connection=local ansible_python_interpreter=auto_silent

--- a/sjust/recipes/shared/01-ai-coding-harness.just
+++ b/sjust/recipes/shared/01-ai-coding-harness.just
@@ -24,6 +24,7 @@ sf-harness-upgrade $force="":
     fi
     ansible-playbook -i "{{sparkdock_path}}/ansible/inventory.ini" \
         "{{sparkdock_path}}/ansible/macos/macos/base.yml" \
+        -e "dev_env_dir={{sparkdock_path}}" \
         -v --tags "ai-harness-sync"
 
 # Show full AI coding harness status: token optimization tools, skills, and agent profiles.


### PR DESCRIPTION
## Summary

`ajust sf-harness-upgrade` fails on Linux with:

```
The module interpreter '/opt/homebrew/bin/python3' was not found.
```

Two macOS-only hardcodings made the playbook unusable off-Apple:

1. `ansible/inventory.ini` pinned `ansible_python_interpreter=/opt/homebrew/bin/python3` — the Homebrew interpreter path doesn't exist on Linux.
2. `ansible/macos/macos/base.yml` set `dev_env_dir: /opt/sparkdock` — the canonical macOS install path; on Linux (via ajust) sparkdock lives under `~/.local/spark/sparkdock`.

Same Ansible flow works on both platforms once those are unpinned — the `--tags ai-harness-sync` blocks just shell out to platform-agnostic scripts (`rtk/setup.sh`, `caveman/setup.sh`, `sparkdock-agents-sync`).

## Changes

- `ansible/inventory.ini`: `ansible_python_interpreter=auto_silent` — let Ansible discover the right Python on each host (no Homebrew assumption, no `auto_legacy` deprecation noise).
- `sjust/recipes/shared/01-ai-coding-harness.just`: pass `-e "dev_env_dir={{sparkdock_path}}"` to `ansible-playbook` so the playbook tracks the actual sparkdock clone location. `sparkdock_path` already resolves correctly in each justfile (`/opt/sparkdock` for sjust on macOS, `${HOME}/.local/spark/sparkdock` for ajust on Linux), so the override is a no-op on macOS and the fix on Linux.
- `CHANGELOG.md`: entry under `### Fixed`.

No OS branching in the recipe, no Linux-specific shim — same playbook, same tags, same flow.

## Test plan

- [x] Linux (Arch, ajust): `ajust sf-harness-upgrade` runs the playbook end-to-end. `PLAY RECAP: ok=9 changed=3 failed=0`. All three target scripts (`rtk/setup.sh`, `caveman/setup.sh`, `sparkdock-agents-sync`) execute against the real sparkdock clone path.
- [ ] macOS (sjust): `sjust sf-harness-upgrade` runs the playbook end-to-end with `dev_env_dir` resolved to `/opt/sparkdock` (same as before — the `-e` override matches the play default on Mac).
- [ ] macOS (sjust): `sjust sf-harness-upgrade force` still exports `SPARKDOCK_AGENTS_FORCE=true` before invoking ansible.
- [ ] macOS full provisioning (`sparkdock` / no `--tags`): `dev_env_dir` still defaults to `/opt/sparkdock` from the play vars when not passed (this PR only adds it for `sf-harness-upgrade`, so other entrypoints are unchanged).