### PR TITLE
fix(rtk): exclude yadm from rewrite rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed RTK rewriting `yadm` commands to `rtk git` (breaking dotfile management) by adding `^yadm` to `exclude_commands` in `config/rtk/exclude-commands.toml` — upstream bug tracked at [rtk-ai/rtk#TBD](https://github.com/rtk-ai/rtk)
 - Fixed `sf-harness-upgrade` failing on non-macOS hosts (e.g. ajust on Arch Linux) with `module interpreter '/opt/homebrew/bin/python3' was not found` — `ansible/inventory.ini` now uses `ansible_python_interpreter=auto_silent` so Ansible discovers a working Python on any host, and `sf-harness-upgrade` passes `-e dev_env_dir={{sparkdock_path}}` so the playbook tracks the real sparkdock location instead of the hardcoded `/opt/sparkdock`. Same Ansible flow on macOS and Linux.
 - Fixed caveman OpenCode plugin hooks never firing — upstream uses non-existent `session.created` and `tui.prompt.append` hooks; patched to use `chat.message` + `experimental.chat.system.transform` ([caveman#418](https://github.com/JuliusBrussee/caveman/issues/418))
 - Added a "done" banner to the GitHub Copilot section of `sf-caveman-install` mirroring the native installer output for Claude Code and OpenCode, so the Copilot install step has matching visual weight instead of finishing on a single log line

--- a/config/rtk/exclude-commands.toml
+++ b/config/rtk/exclude-commands.toml
@@ -1,5 +1,6 @@
 [hooks]
 exclude_commands = [
+  "^yadm(?:$| )",
   "^git push(?: .*)?(?: --force| -f)(?:$| )",
   "git reset --hard",
   "^(?:kubectl|k)(?: .*)? (?:apply|delete|patch|replace)(?:$| )",

--- a/sjust/scripts/rtk/verify-setup.sh
+++ b/sjust/scripts/rtk/verify-setup.sh
@@ -85,6 +85,7 @@ main() {
     assert_file_contains "${rtk_config}" '^(?:kubectl|k)(?: .*)? (?:apply|delete|patch|replace)(?:$| )'
     assert_file_contains "${rtk_config}" '^(?:terraform|tf)(?: .*)? destroy(?:$| )'
     assert_file_contains "${rtk_config}" '^(?:gh|glab)(?: .*)? (?:merge|close|delete|destroy|cancel|disable)(?:$| )'
+    assert_file_contains "${rtk_config}" '^yadm(?:$| )'
 
     if grep -Fq 'exclude_commands = ["curl"]' "${rtk_config}"; then
         log_error "Old exclude_commands value was not replaced"
@@ -157,6 +158,23 @@ main() {
 
     if [[ "${gh_rc}" -ne 1 ]]; then
         log_error "Expected gh exclusion to exit 1, got ${gh_rc}"
+        exit 1
+    fi
+
+    local yadm_output
+    local yadm_rc
+    set +e
+    yadm_output=$(rtk rewrite "yadm status" 2> /dev/null)
+    yadm_rc=$?
+    set -e
+
+    if [[ -n "${yadm_output}" ]]; then
+        log_error "Excluded yadm command was rewritten: ${yadm_output}"
+        exit 1
+    fi
+
+    if [[ "${yadm_rc}" -ne 1 ]]; then
+        log_error "Expected yadm exclusion to exit 1, got ${yadm_rc}"
         exit 1
     fi
 


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Problem

RTK's rewrite registry treats `yadm` as a git synonym (`src/discover/rules.rs` includes `yadm` in `rewrite_prefixes`). This causes `rtk rewrite "yadm status"` to output `rtk git status`, which fails because yadm uses a separate bare repo (`~/.local/share/yadm/repo.git` with `--work-tree=$HOME`).

This breaks all yadm operations when rtk hooks are active (OpenCode, Claude Code, etc.).

## Fix

Add `"^yadm(?:$| )"` to `config/rtk/exclude-commands.toml` so rtk passes yadm commands through unchanged.

## Upstream

Bug filed at rtk-ai/rtk (PR pending).
