### PR TITLE
feat(brew): switch claude-code to claude-code@latest cask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `cask_latest_packages` list in `config/packages/all-packages.yml` for Homebrew cask packages that should be upgraded to latest on every provisioning run; moved `claude-code` and `copilot-cli` into this list so they stay current automatically
+- Added `cask_latest_packages` list in `config/packages/all-packages.yml` for Homebrew cask packages that should be upgraded to latest on every provisioning run; switched `claude-code` to `claude-code@latest` cask (tracks latest releases instead of stable) and moved it along with `copilot-cli` into this list so they stay current automatically
 - Added `/usr/local/bin/sparkfabrik-claude-code-otel-headers` — Claude Code OTLP `otelHeadersHelper` script. Reads the bearer from Secret Manager via the user's gcloud session.
 - Added drop-in snippet support: `~/.config/spark/shell.d/*.zsh` files are now sourced automatically (lexicographic order) after `~/.config/spark/shell.zsh`, enabling MDM tools and package installers to deploy isolated shell snippets without sharing an edit surface with the user's personal `shell.zsh`
 - Added caveman output compression integration for Claude Code, OpenCode, and GitHub Copilot (`sjust sf-caveman-install`) — reduces AI response tokens ~50% using structured terse-output rules (default mode: full); includes `sf-caveman-uninstall` recipe, Ansible `caveman` tag, and per-agent guard clauses for easy addition/removal of agents

--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -199,6 +199,15 @@
           become: false
           ignore_errors: true
 
+    # Migration: uninstall claude-code (stable) before installing claude-code@latest
+    - name: Remove claude-code stable cask (replaced by claude-code@latest)
+      tags: cask
+      community.general.homebrew_cask:
+        name: claude-code
+        state: absent
+      become: false
+      ignore_errors: true
+
     - name: Install cask packages
       tags: cask
       community.general.homebrew_cask:

--- a/config/packages/all-packages.yml
+++ b/config/packages/all-packages.yml
@@ -28,7 +28,7 @@ cask_packages:
 
 # Cask packages upgraded to latest on every provisioning run
 cask_latest_packages:
-  - claude-code
+  - claude-code@latest
   - copilot-cli
 
 homebrew_packages:


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

Switches from `claude-code` (stable) to `claude-code@latest` cask, which tracks the latest releases instead of pinned stable versions.

### Problem

The `claude-code` cask is pinned to stable releases only. Running `claude update` reports being up-to-date even when newer versions exist (e.g., 2.1.145 vs 2.1.156). The `claude-code@latest` cask tracks all releases.

### Changes

- `config/packages/all-packages.yml`: `claude-code` → `claude-code@latest` in `cask_latest_packages`
- `ansible/macos/macos/base.yml`: migration task that uninstalls the old `claude-code` stable cask before installing `claude-code@latest` (idempotent — no-op if already migrated)
- `CHANGELOG.md`: updated entry

Follow-up to #490.