### PR TITLE
feat(shell): add claude-personal alias for separate personal Claude Code profile

### DIFF
--- a/config/shell/aliases.zsh
+++ b/config/shell/aliases.zsh
@@ -225,6 +225,18 @@ if command_exists copilot; then
   cores() { copilot --allow-all-tools --resume "${@}"; }
 fi
 
+# Claude Code with a separate personal profile.
+# `claude-personal` runs Claude Code against its own config dir (~/.claude_personal),
+# giving it a separate login, usage pool and no org-managed policy.
+# The default `claude` command is left untouched and stays on the work/org account.
+if command_exists claude; then
+  claude-personal() {
+    local config_dir="${HOME}/.claude_personal"
+    [[ -d "${config_dir}" ]] || mkdir -p "${config_dir}"
+    CLAUDE_CONFIG_DIR="${config_dir}" command claude "$@"
+  }
+fi
+
 # Add some opencode aliases.
 if command_exists opencode; then
   alias c='opencode'


### PR DESCRIPTION
Closes #492

## Context

SparkFabrik migrated its primary coding harness to Claude Code. Claude Code usage is finite and shared, and org-managed settings are pushed server-side to the logged-in SparkFabrik account.

To keep personal work separate (separate login, separate usage pool, no org policy), Claude Code supports the built-in `CLAUDE_CONFIG_DIR` env var to isolate config/credentials/MCP/history per directory.

## What changed

Added a `claude-personal` shell function to `config/shell/aliases.zsh` (wrapped in a `command_exists claude` guard, matching the surrounding convention used for `copilot`/`opencode`/`openspec`):

```zsh
if command_exists claude; then
  claude-personal() {
    local config_dir="${HOME}/.claude_personal"
    [[ -d "${config_dir}" ]] || mkdir -p "${config_dir}"
    CLAUDE_CONFIG_DIR="${config_dir}" command claude "$@"
  }
fi
```

- Points `CLAUDE_CONFIG_DIR` at `~/.claude_personal`, creating the dir if absent.
- Passes through all args via `"$@"`.
- Uses `command claude` to avoid recursion.

## How to use

```bash
claude-personal          # interactive, personal account
claude-personal -p "..." # one-shot, personal account
```

## Unchanged

The default `claude` command is **not** modified. It keeps using the work/org account and the shared SparkFabrik usage pool.

## Note

Personal use must follow company policy: personal projects are discouraged while we learn the usage limits.

## Validation

`zsh -n config/shell/aliases.zsh` passes (syntax OK).