### PR TITLE
Add LSP server binaries for Claude Code code-intelligence plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added language server binaries for Claude Code's official code-intelligence plugins so org-level `enabledPlugins` can wire them in without per-machine setup: `intelephense`, `typescript`, `typescript-language-server`, `pyright` to `npm_packages` (covers `php-lsp`, `typescript-lsp`, `pyright-lsp` plugins) and `gopls` to `homebrew_packages` (covers `gopls-lsp` plugin). LSP processes only spawn when matching file extensions are present in the workspace, so devs not working in a given language pay no runtime cost.
 - Added `cask_latest_packages` list in `config/packages/all-packages.yml` for Homebrew cask packages that should be upgraded to latest on every provisioning run; switched `claude-code` to `claude-code@latest` cask (tracks latest releases instead of stable) and moved it along with `copilot-cli` into this list so they stay current automatically
 - Added `/usr/local/bin/sparkfabrik-claude-code-otel-headers` — Claude Code OTLP `otelHeadersHelper` script. Reads the bearer from Secret Manager via the user's gcloud session.
 - Added drop-in snippet support: `~/.config/spark/shell.d/*.zsh` files are now sourced automatically (lexicographic order) after `~/.config/spark/shell.zsh`, enabling MDM tools and package installers to deploy isolated shell snippets without sharing an edit surface with the user's personal `shell.zsh`

--- a/config/packages/all-packages.yml
+++ b/config/packages/all-packages.yml
@@ -86,6 +86,7 @@ homebrew_packages:
   - "node"
   - "php@8.2"
   - golang
+  - gopls
   - gitleaks
   - pre-commit
   - uv
@@ -99,7 +100,11 @@ homebrew_packages:
   - yarn-completion
 
 # NPM Global Packages
-npm_packages: []
+npm_packages:
+  - intelephense
+  - typescript
+  - typescript-language-server
+  - pyright
 
 linked_packages: []
 


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @Bladedu._

Closes sparkfabrik/sparkdock#495

## Summary

Add the language-server binaries required by Claude Code's official code-intelligence plugins so devs get PHP, TypeScript, Python, and Go diagnostics + navigation inside Claude Code with no manual setup.

### `config/packages/all-packages.yml`

- `npm_packages`: add `intelephense`, `typescript`, `typescript-language-server`, `pyright`
- `homebrew_packages`: add `gopls` (alongside existing `golang` formula)

### Plugin → binary mapping (from `anthropics/claude-plugins-official/.claude-plugin/marketplace.json`)

| Plugin                                     | Binary the plugin spawns       |
| ------------------------------------------ | ------------------------------ |
| `php-lsp@claude-plugins-official`        | `intelephense`               |
| `typescript-lsp@claude-plugins-official` | `typescript-language-server` |
| `pyright-lsp@claude-plugins-official`    | `pyright-langserver`         |
| `gopls-lsp@claude-plugins-official`      | `gopls`                      |

## Runtime cost

Claude Code only spawns a language server when the workspace contains files matching that plugin's extension list. Devs not working in a given language pay zero runtime cost; only the on-disk binary footprint (~30 MB intelephense + ~20 MB typescript-language-server + small Go/Python overhead).

## Test plan

- [ ] Local provision picks up new packages (`sjust` or `make` provisioning run installs the four npm packages and `gopls` cleanly).
- [ ] `which intelephense typescript-language-server pyright-langserver gopls` resolves on a freshly provisioned host.
- [ ] After matching managed-settings update lands, `claude plugin list --json` on a PHP/TS/Python/Go project shows the relevant LSP plugin enabled.
- [ ] Open a real PHP file in a Drupal project, edit it: post-edit diagnostics appear in Claude Code within ~4 s. (Verified locally on a ~32k-PHP-file workspace: 9 errors caught instantly on intentional broken code; all cleared after fixes.)