### PR TITLE
fix(shell): fall back to sha256sum when shasum is unavailable

### DIFF
--- a/sjust/recipes/shared/06-shell.just
+++ b/sjust/recipes/shared/06-shell.just
@@ -139,9 +139,13 @@ shell-omz-setup:
         echo "📥 Downloading oh-my-zsh installer..."
         curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh -o "${OMZ_INSTALL_SCRIPT}"
 
-        # Show checksum for verification
+        # Show checksum for verification (shasum or sha256sum, whichever exists)
         echo "🔐 Installer SHA256 checksum:"
-        shasum -a 256 "${OMZ_INSTALL_SCRIPT}"
+        if command -v shasum >/dev/null 2>&1; then
+            shasum -a 256 "${OMZ_INSTALL_SCRIPT}"
+        else
+            sha256sum "${OMZ_INSTALL_SCRIPT}"
+        fi
         echo ""
         echo "💡 You can verify this checksum at: https://github.com/ohmyzsh/ohmyzsh"
         echo ""


### PR DESCRIPTION
The oh-my-zsh setup recipe used 'shasum -a 256' directly, which fails on systems without the perl shasum (e.g. a minimal Arch base), aborting shell setup with rc 127. Mirror the portable fallback already used by compute_sha256 in bin/common/utils.sh.