### PR TITLE
fix(ansible): chown root-owned homebrew python files before brew install

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,8 @@ sjust install-tags "docker,keyboard"
 - Package definitions: `config/packages/all-packages.yml`
 - Supports tagging for selective installation
 
+**Privilege escalation (`become`/sudo).** The play in `ansible/macos.yml` runs with `become: true` / `become_user: root`; the sudo password comes from the `ANSIBLE_BECOME_PASS` env var, which the `just run-ansible-playbook` recipe reads interactively (`read -rsp`) and exports (empty string in CI, gated by `CI`/`GITHUB_ACTIONS`). Because Homebrew refuses to run as root, the brew/cask/npm tasks individually opt out with `become: false`; cask tasks instead pass `sudo_password: "{{ ansible_become_pass | default(omit) }}"` to the module. **To run a task as root, simply omit `become: false`** (it inherits `become: true` from the play) — no need to re-declare it. Guard root tasks that must not run in CI with `when: not is_non_interactive`.
+
 **SparkJust Task Runner:**
 
 - Wrapper around Just task runner: `sjust/sjust.sh`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed intermittent `apply2files - Permission denied` failures during `brew install` (e.g. `gopls`) caused by root-owned `.pyc`/files under `{{ homebrew_prefix }}/lib/python*` and `Cellar/python*` — a new `become`-elevated task chowns mis-owned Python files back to the invoking user before the Homebrew package step (idempotent, no-op when ownership is already correct, skipped in non-interactive/CI runs)
 - Fixed RTK rewriting `yadm` commands to `rtk git` (breaking dotfile management) by adding `^yadm` to `exclude_commands` in `config/rtk/exclude-commands.toml` — upstream bug tracked at [rtk-ai/rtk#TBD](https://github.com/rtk-ai/rtk)
 - Fixed `sf-harness-upgrade` failing on non-macOS hosts (e.g. ajust on Arch Linux) with `module interpreter '/opt/homebrew/bin/python3' was not found` — `ansible/inventory.ini` now uses `ansible_python_interpreter=auto_silent` so Ansible discovers a working Python on any host, and `sf-harness-upgrade` passes `-e dev_env_dir={{sparkdock_path}}` so the playbook tracks the real sparkdock location instead of the hardcoded `/opt/sparkdock`. Same Ansible flow on macOS and Linux.
 - Fixed caveman OpenCode plugin hooks never firing — upstream uses non-existent `session.created` and `tui.prompt.append` hooks; patched to use `chat.message` + `experimental.chat.system.transform` ([caveman#418](https://github.com/JuliusBrussee/caveman/issues/418))

--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -283,6 +283,27 @@
         - npm_available.stdout == "available"
         - all_removed_npm_packages | length > 0
 
+    - name: Fix ownership of Homebrew Python files (prevents "apply2files Permission denied" on brew install)
+      tags: brew_packages
+      ansible.builtin.shell: |
+        set -uo pipefail
+        owner="{{ ansible_facts['user_id'] }}"
+        fixed=0
+        for base in "{{ homebrew_prefix }}/lib" "{{ homebrew_prefix }}/Cellar"; do
+          [ -d "${base}" ] || continue
+          for dir in "${base}"/python*; do
+            [ -d "${dir}" ] || continue
+            count=$(find "${dir}" ! -user "${owner}" -print -exec chown "${owner}:admin" {} + 2>/dev/null | wc -l | tr -d ' ')
+            fixed=$((fixed + count))
+          done
+        done
+        echo "fixed=${fixed}"
+      args:
+        executable: /bin/bash
+      register: brew_python_perms
+      changed_when: "'fixed=0' not in brew_python_perms.stdout"
+      when: not is_non_interactive
+
     - name: Install homebrew packages
       tags: brew_packages
       community.general.homebrew:

--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -293,7 +293,7 @@
           [ -d "${base}" ] || continue
           for dir in "${base}"/python*; do
             [ -d "${dir}" ] || continue
-            count=$(find "${dir}" ! -user "${owner}" -print -exec chown "${owner}:admin" {} + 2>/dev/null | wc -l | tr -d ' ')
+            count=$(find "${dir}" ! -user "${owner}" -print -exec chown "${owner}" {} + 2>/dev/null | wc -l | tr -d ' ')
             fixed=$((fixed + count))
           done
         done


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

Fixes intermittent provisioning failures at the **Install homebrew packages** task with `Error: Permission denied @ apply2files - .../python3.14/.../__pycache__/*.pyc`.

**Root cause:** `.pyc`/files under `/opt/homebrew/lib/python*` and `Cellar/python*` get left **root-owned** by a past `sudo`/`pip` run. When `brew` relinks/cleans Python during a formula install (e.g. `gopls`), it calls `apply2files` (chmod/chown) on them and fails, because the brew tasks correctly run as the non-root user.

## Changes

- `ansible/macos/macos/base.yml`: new `become`-elevated task **before** the Homebrew package step that chowns mis-owned files under the Homebrew Python dirs back to the invoking user.
  - Idempotent — `find ! -user "$owner"` only touches mis-owned files; `changed_when` true only when something was fixed.
  - Skipped in non-interactive/CI runs (`when: not is_non_interactive`).
- `AGENTS.md`: documented how `become`/sudo invocation works in this playbook (play-level `become: true`, `ANSIBLE_BECOME_PASS` from the `just` recipe, brew tasks opting out with `become: false`) so future agents know to just omit `become: false` for root tasks.
- `CHANGELOG.md`: `### Fixed` entry.

## Test

- `make run-ansible-playbook TAGS=brew_packages` on a machine exhibiting the error no longer fails on `apply2files`.

Closes #499