### PR TITLE
feat(claude): make statusline context warning dynamic per model window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Claude Code statusline context warning is now dynamic against the active model's context window: shows `ctx NN%/1M` (or `/200k`), colored cyan/amber/red by usage, using Claude Code's `context_window.used_percentage` and `context_window_size`. Falls back to the fixed `⚠ 200k+` flag on older builds that don't emit `context_window`
+- Claude Code statusline context warning is now dynamic against the active model's context window: shows `ctx NN%/1M` (or `/200k`), colored cyan/amber/red by usage, using Claude Code's `context_window.used_percentage` and `context_window.context_window_size`. Falls back to the fixed `⚠ 200k+` flag on older builds that don't emit `context_window`
 - Renamed sjust group `ai-coding-agents` → `ai-coding-harness` and commands `sf-agents-status` → `sf-harness-status`, `sf-agents-sync` → `sf-harness-sync`, `sf-agents-upgrade` → `sf-harness-upgrade`; old names kept as deprecated aliases with notice. Recipe file renamed `01-ai-coding-agents.just` → `01-ai-coding-harness.just`. Ansible tag updated to `ai-coding-harness` (keeping `skills` for backward compat)
 - Copilot custom instructions now write only to `~/.copilot/copilot-instructions.md` (official Copilot CLI local instructions path per GitHub docs); dropped undocumented `~/.github/copilot-instructions.md`. Applies to both RTK and caveman setup scripts. Existing orphaned blocks in `~/.github/copilot-instructions.md` are cleaned up automatically on next run
 - Simplified Copilot RTK helper instructions to focus on `rtk-run`, concise command examples, quoted shell operators, and raw-command fallback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Claude Code statusline context warning is now dynamic against the active model's context window: shows `ctx NN%/1M` (or `/200k`), colored cyan/amber/red by usage, using Claude Code's `context_window.used_percentage` and `context_window_size`. Falls back to the fixed `⚠ 200k+` flag on older builds that don't emit `context_window`
 - Renamed sjust group `ai-coding-agents` → `ai-coding-harness` and commands `sf-agents-status` → `sf-harness-status`, `sf-agents-sync` → `sf-harness-sync`, `sf-agents-upgrade` → `sf-harness-upgrade`; old names kept as deprecated aliases with notice. Recipe file renamed `01-ai-coding-agents.just` → `01-ai-coding-harness.just`. Ansible tag updated to `ai-coding-harness` (keeping `skills` for backward compat)
 - Copilot custom instructions now write only to `~/.copilot/copilot-instructions.md` (official Copilot CLI local instructions path per GitHub docs); dropped undocumented `~/.github/copilot-instructions.md`. Applies to both RTK and caveman setup scripts. Existing orphaned blocks in `~/.github/copilot-instructions.md` are cleaned up automatically on next run
 - Simplified Copilot RTK helper instructions to focus on `rtk-run`, concise command examples, quoted shell operators, and raw-command fallback

--- a/config/bin/sparkfabrik-claude-statusline
+++ b/config/bin/sparkfabrik-claude-statusline
@@ -45,10 +45,12 @@ if command -v jq >/dev/null 2>&1; then
   cur_dir=$(printf '%s' "$INPUT" | jq -r '.workspace.current_dir // .cwd // empty')
   model=$(printf '%s'   "$INPUT" | jq -r '.model.display_name // empty')
   over200=$(printf '%s' "$INPUT" | jq -r '.exceeds_200k_tokens // false')
+  ctx_pct=$(printf '%s' "$INPUT" | jq -r '.context_window.used_percentage // empty')
+  ctx_size=$(printf '%s' "$INPUT" | jq -r '.context_window.context_window_size // empty')
   five_pct=$(printf '%s'  "$INPUT" | jq -r '.rate_limits.five_hour.used_percentage // empty')
   seven_pct=$(printf '%s' "$INPUT" | jq -r '.rate_limits.seven_day.used_percentage // empty')
 else
-  cur_dir="$PWD"; model=""; over200="false"; five_pct=""; seven_pct=""
+  cur_dir="$PWD"; model=""; over200="false"; ctx_pct=""; ctx_size=""; five_pct=""; seven_pct=""
 fi
 
 # Color an integer usage percentage: cyan < 70, amber 70–89, red ≥ 90.
@@ -75,8 +77,23 @@ fi
 # --- model --------------------------------------------------------------------
 [ -n "$model" ] && append "$(printf '\033[33m%s\033[0m' "$(clean "$model")")"
 
-# --- context warning ----------------------------------------------------------
-[ "$over200" = "true" ] && append "$(printf '\033[31m\xe2\x9a\xa0 200k+\033[0m')"
+# --- context window usage -----------------------------------------------------
+# Dynamic: percentage of the *current model's* context window (200k or 1M when
+# extended), not a fixed 200k threshold. Falls back to the exceeds_200k_tokens
+# flag on older Claude Code builds that don't emit `context_window`.
+ctx_int=$(printf '%s' "$ctx_pct" | cut -d. -f1)
+if printf '%s' "$ctx_int" | grep -Eq '^[0-9]+$'; then
+  case "$ctx_size" in
+    1000000) win="1M" ;;
+    200000)  win="200k" ;;
+    *)       win="" ;;
+  esac
+  label="ctx ${ctx_int}%"
+  [ -n "$win" ] && label="${label}/${win}"
+  append "$(printf '\033[38;5;%sm%s\033[0m' "$(pct_color "$ctx_int")" "$label")"
+elif [ "$over200" = "true" ]; then
+  append "$(printf '\033[31m\xe2\x9a\xa0 200k+\033[0m')"
+fi
 
 # --- usage (rate limits) ------------------------------------------------------
 # Mirrors `/usage`: five_hour = current session, seven_day = current week.


### PR DESCRIPTION
## What

Statusline context warning now scales to the **active model's** context window instead of a fixed 200k threshold.

- Reads Claude Code's `context_window.used_percentage` and `context_window.context_window_size`.
- Renders `ctx NN%/1M` (or `/200k`), colored cyan/amber/red by usage (reuses existing `pct_color`: cyan <70, amber 70–89, red ≥90).
- Falls back to the old `⚠ 200k+` flag on older Claude Code builds that don't emit `context_window`.

## Why

Opus 4.8 (and other extended models) run a 1M window. The hardcoded `exceeds_200k_tokens` warning fired at 20% on a 1M model — misleading. Dynamic % reflects real headroom.

## Test

```
$ printf '%s' '{"context_window":{"used_percentage":42.7,"context_window_size":1000000}, ...}' | bash sparkfabrik-claude-statusline
... | ctx 42%/1M

$ printf '%s' '{"exceeds_200k_tokens":true}' | bash sparkfabrik-claude-statusline   # fallback
... | ⚠ 200k+
```

- shellcheck `stable`: clean (exit 0)
- CHANGELOG updated under `### Changed`