### PR TITLE
fix(ansible): report real failing task in menubar install rescue

### DIFF
--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -765,21 +765,12 @@
           when: not is_non_interactive
 
       rescue:
-        - name: Display compilation failure message
+        - name: Report which task actually failed
           debug:
             msg:
-              - "❌ Sparkdock Menu Bar App compilation failed!"
-              - ""
-              - "This is often caused by issues with Xcode command line tools."
-              - "Common symptoms include Swift compiler errors or missing headers."
-              - ""
-              - "🔧 To fix this issue, run the following command:"
-              - "   sjust sparkdock-menubar-reinstall"
-              - ""
-              - "This command will:"
-              - "  1. Remove existing Xcode command line tools"
-              - "  2. Reinstall them properly"
-              - "  3. Retry the menubar app installation"
+              - "❌ Sparkdock Menu Bar App installation failed!"
+              - "Failed task: {{ ansible_failed_task.name | default('unknown') }}"
+              - "Error: {{ ansible_failed_result.msg | default(ansible_failed_result) | default('see output above') }}"
 
         - name: Show build error output
           debug:
@@ -790,10 +781,22 @@
               - "{{ build_result.stderr_lines | default(['No stderr']) }}"
           when: build_result is defined
 
-        - name: Fail with helpful message
+        - name: Show Xcode command line tools hint (compilation failures only)
+          debug:
+            msg:
+              - "This looks like a Swift compilation problem (build returned rc={{ build_result.rc }})."
+              - "Common causes: broken Xcode command line tools, missing headers."
+              - ""
+              - "🔧 To fix, run:"
+              - "   sjust sparkdock-menubar-reinstall"
+              - ""
+              - "This will remove and reinstall the Xcode command line tools, then retry the install."
+          when: build_result is defined and build_result.rc != 0
+
+        - name: Fail with context-aware message
           fail:
-            msg: |
-              Menubar app compilation failed. Run 'sjust sparkdock-menubar-reinstall' to fix Xcode command line tools and retry installation.
+            msg: >-
+              {% if build_result is defined and build_result.rc != 0 %}Menubar app compilation failed. Run 'sjust sparkdock-menubar-reinstall' to fix Xcode command line tools and retry installation.{% else %}Menubar app install failed at task '{{ ansible_failed_task.name | default('unknown') }}': {{ ansible_failed_result.msg | default('see output above') }}{% endif %}
 
     - name: Configure OpenCode settings
       tags: opencode


### PR DESCRIPTION
## Problem

`sjust sparkdock-menubar-install` fails with `Menubar app compilation failed. Run 'sjust sparkdock-menubar-reinstall'...` — but the build actually **succeeds** (`rc=0`, `Build complete!`). The rescue block's `Show build error output` task confirms an empty stderr and a successful build.

## Root cause

The `rescue:` in `ansible/macos/macos/base.yml` is shared across the whole block (build, sudo binary `copy`, `--status` verify, launchctl), but the final `fail` task hardcodes a *compilation-failed* message. When a **post-build** task fails, users are wrongly sent to reinstall Xcode command line tools, which can't fix the actual problem.

## Fix

- Report the real failing task via `ansible_failed_task` / `ansible_failed_result` (magic vars available in rescue).
- Show the Xcode CLT reinstall hint **only** when the build genuinely failed (`build_result.rc != 0`).
- Make the final `fail` message context-aware instead of always blaming compilation.

## Notes

Root cause of the original failure is a post-build task (binary copy / verify), not compilation. This PR makes that self-diagnosing for future runs.

Closes #503