### PR TITLE
feat(claude): show reasoning effort level on managed statusline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added reasoning effort level (`⚡ high`) to the managed Claude Code statusline — reads `effortLevel` from the stdin payload when present, falling back to `~/.claude/settings.json`; magenta when `max`
 - Added language server binaries for Claude Code's official code-intelligence plugins so org-level `enabledPlugins` can wire them in without per-machine setup: `intelephense`, `typescript`, `typescript-language-server`, `pyright` to `npm_packages` (covers `php-lsp`, `typescript-lsp`, `pyright-lsp` plugins) and `gopls` to `homebrew_packages` (covers `gopls-lsp` plugin). LSP processes only spawn when matching file extensions are present in the workspace, so devs not working in a given language pay no runtime cost.
 - Added `cask_latest_packages` list in `config/packages/all-packages.yml` for Homebrew cask packages that should be upgraded to latest on every provisioning run; switched `claude-code` to `claude-code@latest` cask (tracks latest releases instead of stable) and moved it along with `copilot-cli` into this list so they stay current automatically
 - Added `/usr/local/bin/sparkfabrik-claude-code-otel-headers` — Claude Code OTLP `otelHeadersHelper` script. Reads the bearer from Secret Manager via the user's gcloud session.

--- a/config/bin/sparkfabrik-claude-statusline
+++ b/config/bin/sparkfabrik-claude-statusline
@@ -49,8 +49,16 @@ if command -v jq >/dev/null 2>&1; then
   ctx_size=$(printf '%s' "$INPUT" | jq -r '.context_window.context_window_size // empty')
   five_pct=$(printf '%s'  "$INPUT" | jq -r '.rate_limits.five_hour.used_percentage // empty')
   seven_pct=$(printf '%s' "$INPUT" | jq -r '.rate_limits.seven_day.used_percentage // empty')
+  effort=$(printf '%s'   "$INPUT" | jq -r '.effortLevel // .effort // empty')
 else
-  cur_dir="$PWD"; model=""; over200="false"; ctx_pct=""; ctx_size=""; five_pct=""; seven_pct=""
+  cur_dir="$PWD"; model=""; over200="false"; ctx_pct=""; ctx_size=""; five_pct=""; seven_pct=""; effort=""
+fi
+
+# Claude Code doesn't (yet) emit the effort level on stdin, so fall back to the
+# persisted default in settings.json. Tolerates jq absence and a corrupt file.
+if [ -z "$effort" ] && command -v jq >/dev/null 2>&1; then
+  settings="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"
+  [ -f "$settings" ] && effort=$(jq -r '.effortLevel // empty' "$settings" 2>/dev/null) || effort="${effort:-}"
 fi
 
 # Color an integer usage percentage: cyan < 70, amber 70–89, red ≥ 90.
@@ -76,6 +84,18 @@ fi
 
 # --- model --------------------------------------------------------------------
 [ -n "$model" ] && append "$(printf '\033[33m%s\033[0m' "$(clean "$model")")"
+
+# --- effort -------------------------------------------------------------------
+# Reasoning effort level. `high` is the Opus 4.8 default (calm green); `max` is
+# boosted (magenta); `low`/`medium` are downgrades worth flagging (amber).
+if [ -n "$effort" ]; then
+  case "$effort" in
+    max)         ecolor=201 ;;
+    low|medium)  ecolor=178 ;;
+    *)           ecolor=114 ;;
+  esac
+  append "$(printf '\033[38;5;%sm\xe2\x9a\xa1 %s\033[0m' "$ecolor" "$(clean "$effort")")"
+fi
 
 # --- context window usage -----------------------------------------------------
 # Dynamic: percentage of the *current model's* context window (200k or 1M when


### PR DESCRIPTION
## Summary

Adds a reasoning-effort segment to the managed Claude Code statusline (`config/bin/sparkfabrik-claude-statusline`), rendered after the model as `⚡ <level>`.

- **Source:** stdin `effortLevel`/`effort` if Claude Code emits it, else falls back to `effortLevel` in `~/.claude/settings.json` (where `/effort` persists it).
- **Colors:** `high` = calm green (Opus 4.8 default), `max` = magenta (boosted), `low`/`medium` = amber (downgrades worth flagging).
- Value sanitized via `clean()`; degrades gracefully when jq or the key is absent (badge hidden).

## Testing

- Rendered all four levels (low/medium/high/max) — correct colors.
- stdin `effortLevel` override verified.
- `shellcheck` (koalaman/shellcheck:stable) — PASS.

## Notes

`max`/`xhigh` are Opus-tier only; Sonnet 4.6 supports `low`/`medium`/`high`. Badge is model-agnostic — renders whatever `effortLevel` is set.

Closes #505