### PR TITLE
fix(claude): parse object-shaped effortLevel from statusline stdin

### DIFF
--- a/config/bin/sparkfabrik-claude-statusline
+++ b/config/bin/sparkfabrik-claude-statusline
@@ -49,16 +49,17 @@ if command -v jq >/dev/null 2>&1; then
   ctx_size=$(printf '%s' "$INPUT" | jq -r '.context_window.context_window_size // empty')
   five_pct=$(printf '%s'  "$INPUT" | jq -r '.rate_limits.five_hour.used_percentage // empty')
   seven_pct=$(printf '%s' "$INPUT" | jq -r '.rate_limits.seven_day.used_percentage // empty')
-  effort=$(printf '%s'   "$INPUT" | jq -r '.effortLevel // .effort // empty')
+  effort=$(printf '%s'   "$INPUT" | jq -r '(.effortLevel.level? // .effortLevel? // .effort?) // empty')
 else
   cur_dir="$PWD"; model=""; over200="false"; ctx_pct=""; ctx_size=""; five_pct=""; seven_pct=""; effort=""
 fi
 
-# Claude Code doesn't (yet) emit the effort level on stdin, so fall back to the
-# persisted default in settings.json. Tolerates jq absence and a corrupt file.
+# Fall back to the persisted default in settings.json when stdin omits it.
+# settings.json stores effortLevel as a bare string; stdin uses an object — the
+# extraction below handles both. Tolerates jq absence and a corrupt file.
 if [ -z "$effort" ] && command -v jq >/dev/null 2>&1; then
   settings="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"
-  [ -f "$settings" ] && effort=$(jq -r '.effortLevel // empty' "$settings" 2>/dev/null) || effort="${effort:-}"
+  [ -f "$settings" ] && effort=$(jq -r '(.effortLevel.level? // .effortLevel?) // empty' "$settings" 2>/dev/null) || effort="${effort:-}"
 fi
 
 # Color an integer usage percentage: cyan < 70, amber 70–89, red ≥ 90.


### PR DESCRIPTION
## Bug

Follow-up to #506 (merged). Claude Code emits `effortLevel` on the statusline stdin as an **object** (`{"level":"high"}`), not a bare string, so the badge rendered raw JSON:

```
claude-gitlab-ai | main | Opus 4.8 (1M context) | ⚡ {  "level": "high"}
```

## Fix

Extract `.level` when `effortLevel` is an object; fall back to the bare-string shape (`~/.claude/settings.json` stores it as a string):

```
(.effortLevel.level? // .effortLevel? // .effort?) // empty
```

Applied to both the stdin parse and the settings.json fallback.

## Testing

- object stdin `{"level":"high"}` → `⚡ high`
- string stdin `"max"` → `⚡ max`
- settings.json fallback (string) → `⚡ high`
- `shellcheck` (koalaman/shellcheck:stable) — PASS

Closes #507