### PR TITLE
fix(menubar): make install sudo-free and stop empty become pass clobbering prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Menu bar app binary now installs to user-owned `/opt/homebrew/bin/sparkdock-manager` instead of root-owned `/usr/local/bin`, so `sjust sparkdock-menubar-install` no longer needs sudo or a become password (build and LaunchAgent were already user-level)
 - Claude Code statusline context warning is now dynamic against the active model's context window: shows `ctx NN%/1M` (or `/200k`), colored cyan/amber/red by usage, using Claude Code's `context_window.used_percentage` and `context_window.context_window_size`. Falls back to the fixed `⚠ 200k+` flag on older builds that don't emit `context_window`
 - Renamed sjust group `ai-coding-agents` → `ai-coding-harness` and commands `sf-agents-status` → `sf-harness-status`, `sf-agents-sync` → `sf-harness-sync`, `sf-agents-upgrade` → `sf-harness-upgrade`; old names kept as deprecated aliases with notice. Recipe file renamed `01-ai-coding-agents.just` → `01-ai-coding-harness.just`. Ansible tag updated to `ai-coding-harness` (keeping `skills` for backward compat)
 - Copilot custom instructions now write only to `~/.copilot/copilot-instructions.md` (official Copilot CLI local instructions path per GitHub docs); dropped undocumented `~/.github/copilot-instructions.md`. Applies to both RTK and caveman setup scripts. Existing orphaned blocks in `~/.github/copilot-instructions.md` are cleaned up automatically on next run
@@ -131,6 +132,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed an empty `ANSIBLE_BECOME_PASS` env var silently clobbering `--ask-become-pass`: the play-level `ansible_become_pass` is now only set when the env var is non-empty (`| default(omit, true)`), so interactive become prompts (e.g. `sjust sparkdock-install-tags`) are honored instead of failing with `sudo: a password is required`
 - Fixed intermittent `apply2files - Permission denied` failures during `brew install` (e.g. `gopls`) caused by root-owned `.pyc`/files under `{{ homebrew_prefix }}/lib/python*` and `Cellar/python*` — a new `become`-elevated task chowns mis-owned Python files back to the invoking user before the Homebrew package step (idempotent, no-op when ownership is already correct, skipped in non-interactive/CI runs)
 - Fixed RTK rewriting `yadm` commands to `rtk git` (breaking dotfile management) by adding `^yadm` to `exclude_commands` in `config/rtk/exclude-commands.toml` — upstream bug tracked at [rtk-ai/rtk#TBD](https://github.com/rtk-ai/rtk)
 - Fixed `sf-harness-upgrade` failing on non-macOS hosts (e.g. ajust on Arch Linux) with `module interpreter '/opt/homebrew/bin/python3' was not found` — `ansible/inventory.ini` now uses `ansible_python_interpreter=auto_silent` so Ansible discovers a working Python on any host, and `sf-harness-upgrade` passes `-e dev_env_dir={{sparkdock_path}}` so the playbook tracks the real sparkdock location instead of the hardcoded `/opt/sparkdock`. Same Ansible flow on macOS and Linux.

--- a/ansible/macos.yml
+++ b/ansible/macos.yml
@@ -1,8 +1,9 @@
 ---
+# Fact-gathering play: facts feed the import_playbook `when` below.
+# Runs unprivileged — root work is elevated per-task in base.yml, so this
+# must not force a sudo password for the whole run.
 - hosts: 127.0.0.1
   connection: local
-  become: true
-  become_user: root
 
 - name: Import playbook for macOS
   import_playbook: macos/macos/base.yml

--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -10,10 +10,11 @@
     homebrew_prefix: "{{ (ansible_facts['machine'] == 'arm64') | ternary('/opt/homebrew', '/usr/local') }}"
     homebrew_install_path: "{{ homebrew_prefix }}/Homebrew"
     homebrew_brew_bin_path: "{{ homebrew_prefix }}/bin"
-    ansible_become_pass: "{{ lookup('env', 'ANSIBLE_BECOME_PASS') }}"
+    ansible_become_pass: "{{ lookup('env', 'ANSIBLE_BECOME_PASS') | default(omit, true) }}"
 
   tasks:
     - name: Check if running in non-interactive environment
+      tags: always
       set_fact:
         is_non_interactive: "{{ ansible_facts['env'].CI is defined or ansible_facts['env'].GITHUB_ACTIONS is defined or ansible_facts['env'].RUNNER_OS is defined or ansible_facts['env'].HOME == '/var/root' or ansible_facts['env'].ANSIBLE_SUDO_PASSWORD is defined }}"
 
@@ -714,14 +715,12 @@
         - name: Install menu bar app binary
           copy:
             src: "{{ dev_env_dir }}/src/menubar-app/.build/release/sparkdock-manager"
-            dest: "/usr/local/bin/sparkdock-manager"
+            dest: "{{ homebrew_brew_bin_path }}/sparkdock-manager"
             mode: "0755"
             remote_src: true
-          become: yes
-          become_method: sudo
 
         - name: Verify menu bar app works
-          command: /usr/local/bin/sparkdock-manager --status
+          command: "{{ homebrew_brew_bin_path }}/sparkdock-manager --status"
           register: sparkdock_status
           changed_when: false
 

--- a/sjust/recipes/00-default.just
+++ b/sjust/recipes/00-default.just
@@ -342,16 +342,13 @@ sparkdock-upgrade:
 [group('sparkdock')]
 sparkdock-menubar-install:
     #!/usr/bin/env bash
+    set -euo pipefail
     echo "Rebuilding and installing Sparkdock menu bar application..."
     cd {{ sparkdock_path }}
     echo "🔧 Running ansible with menubar tag to rebuild and install..."
-    # Check if running in CI/non-interactive mode (detect based on common CI environment variables)
-    if [[ -n "$CI" || -n "$GITHUB_ACTIONS" || -n "$NON_INTERACTIVE" ]]; then
-        echo "🤖 Detected non-interactive environment, running without password prompt..."
-        ansible-playbook -i ansible/inventory.ini ansible/macos.yml -v --tags "menubar" -e "ansible_become_password=" --become
-    else
-        ansible-playbook -i ansible/inventory.ini ansible/macos.yml -v --tags "menubar" --ask-become-pass
-    fi
+    # No sudo needed: binary installs to user-owned /opt/homebrew/bin and the
+    # LaunchAgent is user-level, so no become password is required.
+    ansible-playbook -i ansible/inventory.ini ansible/macos.yml -v --tags "menubar"
     echo "✅ Sparkdock menu bar app rebuilt and installed successfully!"
     echo "💡 The app should now be running via LaunchAgent"
 

--- a/spec/sparkdock-manager.md
+++ b/spec/sparkdock-manager.md
@@ -9,6 +9,7 @@ Sparkdock Manager is a native macOS menu bar application built with Swift that p
 ## Architecture
 
 ### Component Hierarchy
+
 - NSApplication → SparkdockMenubarApp (NSApplicationDelegate)
   - NSStatusItem (menu bar presence)
   - NSMenu (dropdown interface)
@@ -17,12 +18,14 @@ Sparkdock Manager is a native macOS menu bar application built with Swift that p
   - Process (external command execution with async timeout)
 
 ### Design Patterns
+
 - **Delegate Pattern**: NSApplicationDelegate for lifecycle management
 - **Target-Action**: Menu item event handling
 - **Observer Pattern**: System event notifications for efficient monitoring
 - **Caching**: Icon state caching for performance
 
 ### State Management
+
 - Single source of truth: `hasUpdates` boolean property
 - UI updates synchronized through MainActor
 - No persistent state between launches
@@ -31,12 +34,14 @@ Sparkdock Manager is a native macOS menu bar application built with Swift that p
 ## Key Files and Structure
 
 **Core Implementation:**
+
 - `Sources/SparkdockManager/main.swift` - Complete application implementation (~400 lines)
 - `Sources/SparkdockManager/Resources/menu.json` - Menu structure configuration
 - `Sources/SparkdockManager/Resources/sparkfabrik-logo.png` - Custom logo asset
 - `com.sparkfabrik.sparkdock.menubar.plist` - LaunchAgent configuration
 
 **Configuration Models:**
+
 ```swift
 // JSON-based menu configuration with Codable
 struct MenuConfig { let version: String; let menu: MenuStructure }
@@ -47,6 +52,7 @@ struct MenuItem { let title: String; let type: MenuItemType; let command/url: St
 ## Data Flow
 
 ### Update Check Sequence
+
 1. System event triggers (wake from sleep or network connectivity) → `checkForUpdates()`
 2. Background Task spawned with `.background` priority
 3. Async process executes `/opt/sparkdock/bin/sparkdock.macos check-updates` with structured concurrency timeout
@@ -54,6 +60,7 @@ struct MenuItem { let title: String; let type: MenuItemType; let command/url: St
 5. MainActor synchronizes UI component updates
 
 ### Menu Interaction Flow
+
 1. User clicks menu item → Target-action invokes handler
 2. Dynamic items route through `handleDynamicMenuItem(_:)`
 3. Command items: Executed via AppleScript in Terminal.app
@@ -62,11 +69,13 @@ struct MenuItem { let title: String; let type: MenuItemType; let command/url: St
 ## Update Detection
 
 The app executes `/opt/sparkdock/bin/sparkdock.macos check-updates` to detect available updates:
+
 - **Exit code 0**: Updates available (shows orange tinted icon)
-- **Non-zero exit**: No updates (shows template gray icon)  
+- **Non-zero exit**: No updates (shows template gray icon)
 - **Timeout/Error**: Assumes no updates, logs error
 
 **Modern Async Timeout Protection:**
+
 ```swift
 // Uses structured concurrency with withTaskCancellationHandler
 let finished = await withTaskCancellationHandler(
@@ -86,6 +95,7 @@ let finished = await withTaskCancellationHandler(
 ## Menu Structure
 
 **Static Items:**
+
 - Title: "Sparkdock Manager" (disabled, visual header)
 - Status indicator: Shows "⏳ Checking...", "🔄 Updates Available", or "✅ Up to date"
 - Update Now button: Hidden when no updates available
@@ -93,17 +103,20 @@ let finished = await withTaskCancellationHandler(
 
 **Dynamic Items:**
 Loaded from `menu.json` with configurable sections. Each item supports:
+
 - `"type": "command"` - Executes terminal command via AppleScript
 - `"type": "url"` - Opens URL as Chrome web app (standalone window without browser UI)
 
 **Chrome Web App Integration:**
 URL menu items launch as standalone Chrome windows using the `--app` flag, providing a cleaner, app-like experience:
+
 - URLs open in dedicated Chrome windows without browser chrome (no tabs, address bar, or bookmarks)
 - Fallback to default browser if Chrome unavailable
 - Command: `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome --app=<URL>`
 - Implementation: `openUrlAsChromeWebApp()` function in main.swift
 
 **Example menu.json structure:**
+
 ```json
 {
   "version": "1.0",
@@ -111,11 +124,19 @@ URL menu items launch as standalone Chrome windows using the `--app` flag, provi
     "sections": [
       {
         "name": "Tools",
-        "items": [{"title": "Open sjust", "type": "command", "command": "sjust"}]
+        "items": [
+          { "title": "Open sjust", "type": "command", "command": "sjust" }
+        ]
       },
       {
         "name": "Company",
-        "items": [{"title": "Company Playbook", "type": "url", "url": "https://playbook.sparkfabrik.com/"}]
+        "items": [
+          {
+            "title": "Company Playbook",
+            "type": "url",
+            "url": "https://playbook.sparkfabrik.com/"
+          }
+        ]
       }
     ]
   }
@@ -127,18 +148,21 @@ URL menu items launch as standalone Chrome windows using the `--app` flag, provi
 **Requirements:** macOS 14.0+ (Sonoma)
 
 **Dependencies:**
+
 - **System Frameworks**: Cocoa, ServiceManagement, os.log, Network
 - **External Dependencies**: None (pure Swift, no SPM dependencies)
 - **Resource Dependencies**: Optional logo PNG, required menu.json
 
 **Bundle and Resource Management:**
+
 ```swift
 // SPM resource loading with fallback pattern
-Bundle.module.path(forResource: name, ofType: "png") ?? 
+Bundle.module.path(forResource: name, ofType: "png") ??
 Bundle.main.path(forResource: name, ofType: "png")
 ```
 
 **Icon Management:**
+
 - Custom logo from `sparkfabrik-logo.png` resource (18x18 recommended)
 - Fallback to SF Symbols `gearshape.fill` with configuration
 - Orange tint overlay for update state using `NSColor.systemOrange`
@@ -146,6 +170,7 @@ Bundle.main.path(forResource: name, ofType: "png")
 - Template mode for normal state, colored for updates
 
 **Process Execution:**
+
 - Modern async/await with structured concurrency timeout (30 seconds)
 - withTaskCancellationHandler for automatic process cleanup on timeout
 - AppleScript integration via `/usr/bin/osascript` for Terminal commands
@@ -155,6 +180,7 @@ Bundle.main.path(forResource: name, ofType: "png")
 ## Swift/macOS Patterns
 
 ### Swift Patterns Used
+
 - **Structured Concurrency**: Background priority tasks with proper cancellation
 - **withTaskCancellationHandler**: Automatic resource cleanup on task cancellation
 - **withCheckedContinuation**: Bridging callback-based APIs to async/await
@@ -164,6 +190,7 @@ Bundle.main.path(forResource: name, ofType: "png")
 - **Weak References**: Event observer callbacks to prevent retain cycles
 
 ### macOS Integration Patterns
+
 - **Accessory App Policy**: `NSApp.setActivationPolicy(.accessory)` - no dock icon
 - **Menu Bar Lifecycle**: NSStatusItem with variable length
 - **Modern Login Items**: SMAppService.mainApp for Sonoma+
@@ -175,12 +202,14 @@ Bundle.main.path(forResource: name, ofType: "png")
 ## Error Handling Strategy
 
 **By Component:**
+
 - **Resource Loading**: Graceful fallback to SF Symbols if logo missing
 - **Process Execution**: Timeout protection with user alert notifications
 - **Menu Configuration**: Continues with minimal menu if JSON invalid
 - **Login Item Registration**: User alert on SMAppService failure
 
 **User Notifications:**
+
 ```swift
 // Structured error alerts with NSAlert
 private func showErrorAlert(_ title: String, _ message: String) {
@@ -194,11 +223,13 @@ private func showErrorAlert(_ title: String, _ message: String) {
 ## Installation and Deployment
 
 **Local Development:**
-- Binary installed to `/usr/local/bin/sparkdock-manager`
+
+- Binary installed to `/opt/homebrew/bin/sparkdock-manager` (user-owned, no sudo)
 - LaunchAgent configuration for auto-startup
 - Ansible integration with `menubar` tag
 
 **CI/CD Considerations:**
+
 - LaunchAgent installation skipped in CI environments
 - Condition: `when: not (ansible_env.CI is defined or ansible_env.GITHUB_ACTIONS is defined)`
 - Binary installation continues for testing purposes
@@ -214,21 +245,24 @@ private func showErrorAlert(_ title: String, _ message: String) {
 ## Debugging and Logging
 
 **Structured Logging:**
+
 ```swift
 // os.log with subsystem and category
 private static let logger = Logger(
-    subsystem: "com.sparkfabrik.sparkdock.manager", 
+    subsystem: "com.sparkfabrik.sparkdock.manager",
     category: "MenuBar"
 )
 ```
 
 **View logs with:**
+
 ```bash
 # Console.app or command line
 log stream --predicate 'subsystem == "com.sparkfabrik.sparkdock.manager"'
 ```
 
 **Common Issues:**
+
 - Menu not appearing: Check `NSApp.setActivationPolicy(.accessory)`
 - Updates not detected: Verify `/opt/sparkdock/bin/sparkdock.macos` exists
 - Commands not working: Check AppleScript Terminal integration
@@ -246,6 +280,7 @@ swift test                  # Alternative test command
 ```
 
 **Code Style:**
+
 - MARK comments for section organization
 - Private methods with descriptive verb prefixes (setup/load/update)
 - Constants grouped in `AppConstants` struct
@@ -255,13 +290,15 @@ swift test                  # Alternative test command
 ## Testing Strategy
 
 **Current Tests:**
+
 - Package structure validation
-- Resource existence checks  
+- Resource existence checks
 - Path construction verification
 - Command escaping validation
 - Menu item tag uniqueness
 
 **Testing Limitations:**
+
 - Cannot test actual menu display (requires UI automation)
 - Process execution requires mocking or integration tests
 - Login item registration needs user interaction
@@ -271,15 +308,18 @@ swift test                  # Alternative test command
 ### SparkdockMenubarApp Core Methods
 
 **Lifecycle Management:**
+
 - `applicationDidFinishLaunching(_:)` - Setup menu bar, load config, start timer
 - `applicationWillTerminate(_:)` - Cleanup timer, clear image cache
 
 **Update Management:**
+
 - `checkForUpdates()` - Async update check with background Task
 - `runSparkdockCheck() async -> Bool` - Async process execution with structured concurrency timeout
 - `updateUI(hasUpdates: Bool)` - MainActor UI state synchronization
 
 **Menu Event Handlers:**
+
 - `handleDynamicMenuItem(_:)` - Routes dynamic menu items to command/URL handlers
 - `openUrlAsChromeWebApp(_:)` - Launches URLs as Chrome web apps with fallback
 - `toggleLoginItem()` - Modern SMAppService login item registration
@@ -287,6 +327,7 @@ swift test                  # Alternative test command
 - `executeTerminalCommand(_:)` - AppleScript-based Terminal command execution
 
 **Utility Methods:**
+
 - `loadIcon(hasUpdates: Bool) -> NSImage?` - Cached icon generation with state
 - `showErrorAlert(_: String, _: String)` - User error presentation
 - `loadMenuConfiguration()` - JSON configuration parsing with fallback

--- a/src/menubar-app/Makefile
+++ b/src/menubar-app/Makefile
@@ -12,10 +12,10 @@ dev:
 	@echo "Running in development mode..."
 	./.build/debug/sparkdock-manager
 
-# Install the application (requires sudo for /usr/local/bin)
+# Install the application (user-owned /opt/homebrew/bin, no sudo)
 install: build
-	sudo cp .build/release/sparkdock-manager /usr/local/bin/
-	sudo chmod 755 /usr/local/bin/sparkdock-manager
+	cp .build/release/sparkdock-manager /opt/homebrew/bin/
+	chmod 755 /opt/homebrew/bin/sparkdock-manager
 	cp com.sparkfabrik.sparkdock.menubar.plist ~/Library/LaunchAgents/
 	launchctl unload ~/Library/LaunchAgents/com.sparkfabrik.sparkdock.menubar.plist 2>/dev/null || true
 	launchctl load ~/Library/LaunchAgents/com.sparkfabrik.sparkdock.menubar.plist
@@ -24,7 +24,7 @@ install: build
 uninstall:
 	launchctl unload ~/Library/LaunchAgents/com.sparkfabrik.sparkdock.menubar.plist 2>/dev/null || true
 	rm -f ~/Library/LaunchAgents/com.sparkfabrik.sparkdock.menubar.plist
-	sudo rm -f /usr/local/bin/sparkdock-manager
+	rm -f /opt/homebrew/bin/sparkdock-manager
 
 # Clean build artifacts
 clean:

--- a/src/menubar-app/com.sparkfabrik.sparkdock.menubar.plist
+++ b/src/menubar-app/com.sparkfabrik.sparkdock.menubar.plist
@@ -6,7 +6,7 @@
     <string>com.sparkfabrik.sparkdock.menubar</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/usr/local/bin/sparkdock-manager</string>
+        <string>/opt/homebrew/bin/sparkdock-manager</string>
     </array>
     <key>RunAtLoad</key>
     <true/>


### PR DESCRIPTION
Closes #512

## Problem

`sjust sparkdock-menubar-install` failed with `sudo: a password is required` **even when a password was supplied**, and then printed a false `✅ ... installed successfully` message anyway.

## Root causes (3, compounding)

1. **`ansible/macos.yml`** — an empty play declared `become: true` / `become_user: root`. Its only effect was gathering facts **as root**, forcing a sudo password for the *entire* run regardless of which tasks were selected. Those facts only feed the `import_playbook` `when` condition and need no root.
2. **`base.yml`** — the play-level `ansible_become_pass` was set unconditionally from `lookup('env', 'ANSIBLE_BECOME_PASS')`. Play vars outrank `--ask-become-pass`, so an empty env value silently forced an **empty** become password, discarding the prompted one.
3. **`base.yml`** — the `is_non_interactive` `set_fact` was untagged, so it was skipped under `--tags menubar` and left undefined, crashing the LaunchAgent block (masked until causes 1–2 were fixed).

## Changes

- `macos.yml`: fact-gathering play runs unprivileged.
- `base.yml`: `ansible_become_pass` only set when env is non-empty (`| default(omit, true)`); `is_non_interactive` tagged `always`.
- Menu bar binary installs to **user-owned `/opt/homebrew/bin`** (in PATH on Apple Silicon) instead of root-owned `/usr/local/bin` → whole menubar flow needs **no sudo**. Updated plist, `Makefile`, and spec doc to match.
- Recipe drops password branching and adds `set -euo pipefail`, so a failed run no longer prints a false success message (addresses the issue's expected-behavior note).

> Note: the broader benefit is that the full `sparkdock` provisioning no longer roots fact-gathering either — root is now used only where a task-level `become` declares it.

## Verification (local, Apple Silicon / Tahoe)

Run against the working tree (not the installed `/opt/sparkdock`):

```bash
ansible-playbook -i ansible/inventory.ini ansible/macos.yml -v --tags menubar -e dev_env_dir="$(pwd)"
```

- `failed=0`, **no password prompt**
- binary `owner: paolomainardi` (uid 501, user-owned), `which sparkdock-manager` → `/opt/homebrew/bin/sparkdock-manager`
- `launchctl print gui/$(id -u)/com.sparkfabrik.sparkdock.menubar` → `state = running`, `program = /opt/homebrew/bin/sparkdock-manager`
- rerun idempotent (binary copy reports unchanged)

## Notes

- A stale `/usr/local/bin/sparkdock-manager` from prior installs is left orphaned (not loaded; removing it would itself need sudo).