### PR TITLE
fix(brew): generic receipt-rebind for tap-renamed packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed provisioning failing on machines that installed a package before its Homebrew tap was renamed (e.g. `skhd` pinned to `koekeishiya/formulae`): added a generic step that reinstalls any tap-qualified package whose install receipt no longer matches its declared tap, rebinding it; driven by the existing package list, no-op for fresh installs and already-correct packages
 - Fixed third-party Homebrew tap installs failing on Homebrew 6.x (`HOMEBREW_REQUIRE_TAP_TRUST`) by trusting each configured tap during provisioning; guarded to no-op on Homebrew < 6
 - Fixed `skhd` install failing after its upstream GitHub owner renamed `koekeishiya` → `asmvik`: repointed the tap and package to `asmvik/formulae` and added `koekeishiya/formulae` to `removed_taps`
 - Fixed caveman setup silently skipping Claude Code on Linux: the official Claude installer puts `claude` in `~/.local/bin`, which is absent from the PATH during non-interactive provisioning (the sf-toolbox ansible run executes as root), so `setup_claude`'s `command -v claude` guard failed and the plugin + hooks were never wired. The caveman setup now prepends `~/.local/bin` to PATH before detecting Claude

--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -335,7 +335,7 @@
     - name: Re-bind tap-qualified packages whose install receipt points at a renamed tap
       tags: brew_packages
       ansible.builtin.shell: |
-        set -uo pipefail
+        set -euo pipefail
         # A package installed before its tap was renamed keeps the old tap in its install
         # receipt; `state: latest` is a no-op on the bare name and never rebinds it, so the
         # tap-qualified assert below fails. If the bare formula is installed but the

--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -332,6 +332,27 @@
       when: all_homebrew_packages | length > 0
       become: false
 
+    - name: Re-bind tap-qualified packages whose install receipt points at a renamed tap
+      tags: brew_packages
+      ansible.builtin.shell: |
+        set -uo pipefail
+        # A package installed before its tap was renamed keeps the old tap in its install
+        # receipt; `state: latest` is a no-op on the bare name and never rebinds it, so the
+        # tap-qualified assert below fails. If the bare formula is installed but the
+        # tap-qualified name is not, reinstall to rebind the receipt to the declared tap.
+        name="{{ item.split('/') | last }}"
+        if brew list "${name}" >/dev/null 2>&1 && ! brew list "{{ item }}" >/dev/null 2>&1; then
+          brew reinstall "{{ item }}"
+          echo "rebound"
+        fi
+      args:
+        executable: /bin/bash
+      loop: "{{ all_homebrew_packages | select('search', '/') | list }}"
+      become: false
+      register: tap_rebind
+      changed_when: "'rebound' in tap_rebind.stdout"
+      when: all_homebrew_packages | length > 0
+
     - name: Assert homebrew packages installed
       tags: brew_packages
       shell: |


### PR DESCRIPTION
## Summary

Follow-up to #523. Fixes the `Assert homebrew packages installed` failure (`asmvik/formulae/skhd missing`) on machines that installed `skhd` **before** the upstream tap rename. Replaces a would-be `skhd`-specific reinstall with a generic, data-driven rebind.

## Root cause

The installed `skhd` keg's receipt still records `source.tap = koekeishiya/formulae`. `state: latest` is a no-op on the already-present bare `skhd`, so the receipt never rebinds; the assert's fully-qualified `brew list asmvik/formulae/skhd` strict-matches the receipt tap and reports missing.

## Approach — generic, no hardcoding

New task rebinds **any** tap-qualified package whose receipt no longer matches its declared tap:

- Set derived from the existing `all_homebrew_packages` list (entries containing `/`) — **no new variable**.
- For each: if the bare formula is installed but the tap-qualified name is not, `brew reinstall <tap-qualified>` to rebind the receipt.
- Self-healing for future tap renames — update the qualified name in `config/packages/all-packages.yml` and the next provision rebinds.
- Fresh installs and already-correct packages (`charmbracelet/tap/gum`, `anomalyco/tap/opencode`) are skipped.
- Runs after tap config + trust (#523), so the target tap is tapped and trusted.

## Verification

- Reproduced locally: receipt `source.tap = koekeishiya/formulae` → `brew reinstall asmvik/formulae/skhd` rebinds to `asmvik/formulae`, then `brew list asmvik/formulae/skhd` succeeds.
- Confirmed the jinja derivation: `select('search','/')` yields only tap-qualified entries; `split('/') | last` yields the bare formula name.

Closes #524
