### PR TITLE
fix(claude): gate gh only at command position, not inside arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The Claude `gh` gate now matches `gh` only when it is the command being run (start of the command, or after a `;`/`|`/`&`/newline separator, optionally preceded by env-var assignments), instead of anywhere in the command string. This prevents false-positive blocks when `gh` merely appears inside an argument, such as a commit message that mentions "gh".
 - Menu bar app binary now installs to user-owned `/opt/homebrew/bin/sparkdock-manager` instead of root-owned `/usr/local/bin`, so `sjust sparkdock-menubar-install` no longer needs sudo or a become password (build and LaunchAgent were already user-level)
 - Claude Code statusline context warning is now dynamic against the active model's context window: shows `ctx NN%/1M` (or `/200k`), colored cyan/amber/red by usage, using Claude Code's `context_window.used_percentage` and `context_window.context_window_size`. Falls back to the fixed `⚠ 200k+` flag on older builds that don't emit `context_window`
 - Renamed sjust group `ai-coding-agents` → `ai-coding-harness` and commands `sf-agents-status` → `sf-harness-status`, `sf-agents-sync` → `sf-harness-sync`, `sf-agents-upgrade` → `sf-harness-upgrade`; old names kept as deprecated aliases with notice. Recipe file renamed `01-ai-coding-agents.just` → `01-ai-coding-harness.just`. Ansible tag updated to `ai-coding-harness` (keeping `skills` for backward compat)

--- a/sjust/scripts/claude-gh-gate.py
+++ b/sjust/scripts/claude-gh-gate.py
@@ -44,12 +44,13 @@ from pathlib import Path
 
 GATED_SKILLS = {"gh"}
 
-# Match a gh invocation anywhere in the command string: at the start, or after
-# whitespace, a separator (; & |), an opening paren, or an env-var assignment.
-# The name must be followed by whitespace or end-of-string, so a bare `gh` (no
-# args) is still gated while "github" is not. Also catches RTK-wrapped
-# "rtk-run gh ".
-_GH_RE = re.compile(r"(?:^|[\s;&|(=])gh(?:\s|$)")
+# Match `gh` only when it is the command being run, not when it appears as an
+# argument or inside a quoted string. A command position is the start of the
+# string or just after a shell separator (; | & newline, or an opening paren),
+# optionally preceded by env-var assignments (FOO=bar gh ...). The name must be
+# followed by whitespace or end-of-string, so a bare `gh` is gated while
+# "github" and a "gh" mentioned in an argument (e.g. a commit message) are not.
+_GH_RE = re.compile(r"(?:^|[;&|\n(]\s*)(?:\w+=\S*\s+)*gh(?:\s|$)")
 
 # Stable identifier embedded in the registered command so the installer can find
 # and remove exactly our entries without disturbing other hooks (RTK, caveman).

--- a/sjust/scripts/lib/test_claude_gh_gate.py
+++ b/sjust/scripts/lib/test_claude_gh_gate.py
@@ -89,6 +89,29 @@ class GateHookTest(unittest.TestCase):
             self.run_hook(self.bash("github-release-tool run")).returncode, 0
         )
 
+    def test_gh_as_argument_is_not_gated(self):
+        # The word "gh" inside an argument (e.g. a commit message) must not be
+        # treated as a gh invocation.
+        for cmd in (
+            'git commit -m "feat: enable the gh skill gate"',
+            'echo "gh"',
+            "grep gh file.txt",
+            "rg gh .",
+        ):
+            self.assertEqual(
+                self.run_hook(self.bash(cmd)).returncode, 0, f"should allow: {cmd!r}"
+            )
+
+    def test_gh_after_separators_is_gated(self):
+        for cmd in (
+            "cd /tmp; gh pr list",
+            "cat x | gh pr create",
+            "make build && gh release create",
+        ):
+            self.assertEqual(
+                self.run_hook(self.bash(cmd)).returncode, 2, f"should gate: {cmd!r}"
+            )
+
     def test_non_gh_command_allowed(self):
         self.assertEqual(self.run_hook(self.bash("git push")).returncode, 0)
 


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Problem

The gh gate's command regex matched `gh` after **any** whitespace, so it fired when `gh` merely appeared inside an argument: a commit message that mentions "gh", `echo "foo gh bar"`, `grep gh file`, etc. Those benign commands were blocked until the `gh` skill was loaded — needless friction.

## Fix

Match `gh` only when it is the command being run: at the start of the command, or right after a separator (`;` `|` `&` newline, or an opening paren), optionally preceded by env-var assignments.

```
- (?:^|[\s;&|(=])gh(?:\s|$)
+ (?:^|[;&|\n(]\s*)(?:\w+=\S*\s+)*gh(?:\s|$)
```

Still gates `gh …`, `FOO=1 gh …`, `cmd; gh …`, `a | gh …`, `a && gh …`, and a bare `gh`; no longer fires on `gh` inside an argument. Trade-off: it no longer matches `rtk-run gh` (gh as an argument to another command), which is acceptable — the agent runs `gh` directly.

## Tests

Added cases to `test_claude_gh_gate.py`: `gh`-as-argument (allowed) and `gh`-after-separator (gated). Full suite: 43 tests pass; `ruff` clean.

## Live validation (`claude -p`)

Real before/after with a headless session running `echo "foo gh bar"`:
- **Old regex:** blocked the echo, forcing an unnecessary `gh` skill load (a new per-session sentinel appeared).
- **Fixed:** ran clean, no gate interference (no new sentinel).


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix `gh` gate regex to match only command position, not arguments

- Prevents false-positive blocks when `gh` appears in commit messages or args

- Added tests for `gh`-as-argument (allowed) and `gh`-after-separator (gated)

- Updated `CHANGELOG.md` to document the regex behavior change


___

### Diagram Walkthrough


```mermaid
flowchart LR
  old["Old regex: matches gh anywhere after whitespace"]
  new["New regex: matches gh only at command position"]
  sep["After separator (; | & newline paren)"]
  env["Optional env-var assignments (FOO=bar)"]
  arg["gh in arguments (commit messages, grep, echo)"]
  old -- "false positive" --> arg
  sep -- "feeds into" --> new
  env -- "feeds into" --> new
  new -- "correctly allows" --> arg
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>claude-gh-gate.py</strong><dd><code>Fix gh gate regex to match command position only</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sjust/scripts/claude-gh-gate.py

<ul><li>Updated <code>_GH_RE</code> regex from <code>(?:^|[\s;&|(=])gh(?:\s|$)</code> to <br><code>(?:^|[;&|\n(]\s*)(?:\w+=\S*\s+)*gh(?:\s|$)</code><br> <li> New regex matches <code>gh</code> only at command position: start of string or <br>after shell separators<br> <li> Supports optional leading env-var assignments (e.g. <code>FOO=bar gh ...</code>)<br> <li> No longer fires when <code>gh</code> appears inside an argument or quoted string</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/529/files#diff-095e60bf06195a4e2632dee59c655825dae981a3c950959847ded8242913e074">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_claude_gh_gate.py</strong><dd><code>Add tests for gh-as-argument and gh-after-separator cases</code></dd></summary>
<hr>

sjust/scripts/lib/test_claude_gh_gate.py

<ul><li>Added <code>test_gh_as_argument_is_not_gated</code> to verify <code>gh</code> in arguments is <br>allowed<br> <li> Added <code>test_gh_after_separators_is_gated</code> to verify <code>gh</code> after <code>;</code>, <code>|</code>, <code>&&</code> is <br>gated<br> <li> Test cases cover commit messages, echo, grep, rg, and shell-chained <br>commands</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/529/files#diff-9051f5faa6652881da923aae1dae987602d750e6ff6be8f2cd19570c439b868c">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document gh gate regex fix in changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added changelog entry describing the updated <code>gh</code> gate regex behavior<br> <li> Documents that <code>gh</code> in arguments (e.g. commit messages) no longer <br>triggers the gate</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/529/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

