### PR TITLE
fix(claude): show fractional weekly usage on the statusline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed the managed Claude Code statusline dropping the weekly (`7d`) usage when Claude Code reports a fractional `seven_day.used_percentage` (e.g. `14.0000002`): the rate-limit percentages are now reduced to their integer part before the numeric check, the same way the context percentage already is. The `5h` value was unaffected only because it happened to be a whole number.
 - Fixed provisioning failing on machines that installed a package before its Homebrew tap was renamed (e.g. `skhd` pinned to `koekeishiya/formulae`): added a generic step that reinstalls any tap-qualified package whose install receipt no longer matches its declared tap, rebinding it; driven by the existing package list, no-op for fresh installs and already-correct packages
 - Fixed third-party Homebrew tap installs failing on Homebrew 6.x (`HOMEBREW_REQUIRE_TAP_TRUST`) by trusting each configured tap during provisioning; guarded to no-op on Homebrew < 6
 - Fixed `skhd` install failing after its upstream GitHub owner renamed `koekeishiya` → `asmvik`: repointed the tap and package to `asmvik/formulae` and added `koekeishiya/formulae` to `removed_taps`

--- a/config/bin/sparkfabrik-claude-statusline
+++ b/config/bin/sparkfabrik-claude-statusline
@@ -119,12 +119,16 @@ fi
 
 # --- usage (rate limits) ------------------------------------------------------
 # Mirrors `/usage`: five_hour = current session, seven_day = current week.
+# Claude Code may send fractional percentages (e.g. 14.0000002), so take the
+# integer part the same way the context percentage does above.
 usage=""
-if printf '%s' "$five_pct" | grep -Eq '^[0-9]+$'; then
-  usage="$(printf '5h \033[38;5;%sm%s%%\033[0m' "$(pct_color "$five_pct")" "$five_pct")"
+five_int=$(printf '%s' "$five_pct" | cut -d. -f1)
+if printf '%s' "$five_int" | grep -Eq '^[0-9]+$'; then
+  usage="$(printf '5h \033[38;5;%sm%s%%\033[0m' "$(pct_color "$five_int")" "$five_int")"
 fi
-if printf '%s' "$seven_pct" | grep -Eq '^[0-9]+$'; then
-  week="$(printf '7d \033[38;5;%sm%s%%\033[0m' "$(pct_color "$seven_pct")" "$seven_pct")"
+seven_int=$(printf '%s' "$seven_pct" | cut -d. -f1)
+if printf '%s' "$seven_int" | grep -Eq '^[0-9]+$'; then
+  week="$(printf '7d \033[38;5;%sm%s%%\033[0m' "$(pct_color "$seven_int")" "$seven_int")"
   if [ -n "$usage" ]; then usage="$usage $week"; else usage="$week"; fi
 fi
 [ -n "$usage" ] && append "$usage"


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Problem

The weekly (`7d`) usage disappeared from the managed statusline. Claude Code now reports rate-limit percentages as **floats** — captured live: `rate_limits.seven_day.used_percentage = 14.000000000000002`, while `five_hour` happened to be the whole number `33`. The script gated each value behind `grep -Eq '^[0-9]+$'`, so the fractional `7d` was rejected (hidden) and the integer `5h` still rendered.

## Fix

Reduce `five_hour` and `seven_day` percentages to their integer part (`cut -d. -f1`) before the numeric check and display — exactly how the context percentage (`ctx_int`) is already handled a few lines above. One consistent approach across all three percentages.

## Verification

Tested the script directly:
- Real captured payload (`7d = 14.0000002`) → renders `5h 33% 7d 14%`.
- Both fractional (`33.9`, `14.7`) → `5h 33% 7d 14%`.
- `seven_day` absent → only `5h`.
- No `rate_limits` → no usage segment.
- shellcheck clean.

Also applied to a live Arch install and confirmed in the real statusline (weekly usage reappeared).


___

### **PR Type**
Bug fix


___

### **Description**
- Fix fractional percentage values dropping from Claude statusline

- Extract integer part of `five_pct` and `seven_pct` before numeric validation

- Updated `CHANGELOG.md` with fix description


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Claude Code API"] -- "returns float\n(e.g. 14.0000002)" --> B["five_pct / seven_pct"]
  B -- "cut -d. -f1" --> C["five_int / seven_int"]
  C -- "grep '^[0-9]+$'" --> D["Numeric validation"]
  D -- "passes" --> E["Statusline renders\n'5h 33% 7d 14%'"]
  B -- "old: direct grep\n'^[0-9]+$'" --> F["Fractional value rejected\n(7d hidden)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sparkfabrik-claude-statusline</strong><dd><code>Truncate fractional percentages before statusline numeric validation</code></dd></summary>
<hr>

config/bin/sparkfabrik-claude-statusline

<ul><li>Extract integer part of <code>five_pct</code> into <code>five_int</code> using <code>cut -d. -f1</code> <br>before numeric check<br> <li> Extract integer part of <code>seven_pct</code> into <code>seven_int</code> using <code>cut -d. -f1</code> <br>before numeric check<br> <li> Use integer variables in both the validation regex and the display <br>output<br> <li> Added comment explaining why fractional truncation is needed</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/530/files#diff-4a86613dbbcfe1b3e1ae4f141fc1017c02bf3eb3f4953c685e70cd070a28af8e">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document fractional percentage statusline fix in changelog</code></dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added entry under "Fixed" describing the fractional <br><code>seven_day.used_percentage</code> bug and its fix</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/530/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

