### PR TITLE
fix(claude): skip the gh gate when gh is not installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The Claude `gh` gate is now a no-op when `gh` is not installed (not on `PATH`): rather than blocking to load the skill before a command that would only fail with "command not found", it lets the command run. No effect on machines that have `gh`.
 - The Claude `gh` gate now matches `gh` only when it is the command being run (start of the command, or after a `;`/`|`/`&`/newline separator, optionally preceded by env-var assignments), instead of anywhere in the command string. This prevents false-positive blocks when `gh` merely appears inside an argument, such as a commit message that mentions "gh".
 - Menu bar app binary now installs to user-owned `/opt/homebrew/bin/sparkdock-manager` instead of root-owned `/usr/local/bin`, so `sjust sparkdock-menubar-install` no longer needs sudo or a become password (build and LaunchAgent were already user-level)
 - Claude Code statusline context warning is now dynamic against the active model's context window: shows `ctx NN%/1M` (or `/200k`), colored cyan/amber/red by usage, using Claude Code's `context_window.used_percentage` and `context_window.context_window_size`. Falls back to the fixed `⚠ 200k+` flag on older builds that don't emit `context_window`

--- a/sjust/scripts/claude-gh-gate.py
+++ b/sjust/scripts/claude-gh-gate.py
@@ -39,6 +39,7 @@ future gates can share the same plumbing.
 import json
 import os
 import re
+import shutil
 import sys
 from pathlib import Path
 
@@ -122,6 +123,10 @@ def run_hook() -> int:
         if not isinstance(command, str) or not _GH_RE.search(command):
             return 0
         if sentinel.exists():
+            return 0
+        if shutil.which("gh") is None:
+            # gh is not installed; gating would only delay a command that is
+            # going to fail anyway. Let it run and fail on its own.
             return 0
         sys.stderr.write(
             "Load the gh (GitHub CLI) skill before running this command.\n"

--- a/sjust/scripts/lib/test_claude_gh_gate.py
+++ b/sjust/scripts/lib/test_claude_gh_gate.py
@@ -31,10 +31,20 @@ class GateHookTest(unittest.TestCase):
     def setUp(self):
         self.tmp = tempfile.TemporaryDirectory()
         self.addCleanup(self.tmp.cleanup)
+        # A controlled PATH so the gate's `shutil.which("gh")` guard is
+        # deterministic regardless of whether the host has gh installed.
+        self.bindir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.bindir.cleanup)
+        gh = Path(self.bindir.name) / "gh"
+        gh.write_text("#!/bin/sh\n")
+        gh.chmod(0o755)
+        self.empty_path = tempfile.TemporaryDirectory()
+        self.addCleanup(self.empty_path.cleanup)
 
-    def run_hook(self, payload, extra_env=None):
+    def run_hook(self, payload, extra_env=None, gh_on_path=True):
         env = dict(os.environ)
         env["TMPDIR"] = self.tmp.name
+        env["PATH"] = self.bindir.name if gh_on_path else self.empty_path.name
         env.pop("SPARKDOCK_GH_GATE", None)
         if extra_env:
             env.update(extra_env)
@@ -66,6 +76,11 @@ class GateHookTest(unittest.TestCase):
         r = self.run_hook(self.bash("gh pr create"))
         self.assertEqual(r.returncode, 2)
         self.assertIn("gh", r.stderr.lower())
+
+    def test_not_gated_when_gh_not_installed(self):
+        # With no gh on PATH, gating would only delay a doomed command; allow it.
+        r = self.run_hook(self.bash("gh pr create"), gh_on_path=False)
+        self.assertEqual(r.returncode, 0)
 
     def test_bare_gh_is_gated(self):
         # Regression: regex must match `gh` with no args (end-of-string), else


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Problem

The gate matches the command text, not whether `gh` exists. On a machine without `gh` installed, the first `gh …` attempt is still blocked to load the skill, then on retry the command runs and fails with `gh: command not found`. The skill-load detour is pointless there.

## Fix

Add a `shutil.which("gh")` guard in the hook: if `gh` is not on `PATH`, allow the command through (it will fail on its own, no skill-load detour). No change on machines that have `gh`.

## Tests

The hook tests now pin `PATH` — a stub `gh` for the block-expecting cases, an empty dir for the new no-`gh` case — so block/allow behavior is deterministic regardless of whether the CI host has `gh`. Added `test_not_gated_when_gh_not_installed`. Full suite: 44 tests pass; `ruff` clean.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Add `shutil.which("gh")` guard to skip gate when `gh` is not installed

- Gate now allows commands through instead of blocking when `gh` is absent from PATH

- Tests pin PATH with stub `gh` or empty dir for deterministic behavior

- Added `test_not_gated_when_gh_not_installed` test case and CHANGELOG entry


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Bash command with 'gh'"] -- "check" --> B["gh on PATH?"]
  B -- "yes" --> C["sentinel exists?"]
  B -- "no (gh absent)" --> D["return 0 (allow)"]
  C -- "yes" --> E["return 0 (allow)"]
  C -- "no" --> F["return 2 (block, load skill)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>claude-gh-gate.py</strong><dd><code>Skip gh gate when gh binary is not on PATH</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sjust/scripts/claude-gh-gate.py

<ul><li>Added <code>import shutil</code> to support <code>shutil.which()</code> check<br> <li> Added guard in <code>run_hook()</code> to return 0 (allow) when <code>gh</code> is not found on <br>PATH<br> <li> Includes explanatory comment about why gating is skipped when <code>gh</code> is <br>absent</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/531/files#diff-095e60bf06195a4e2632dee59c655825dae981a3c950959847ded8242913e074">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_claude_gh_gate.py</strong><dd><code>Add deterministic PATH control and no-gh test case</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sjust/scripts/lib/test_claude_gh_gate.py

<ul><li><code>setUp</code> now creates a stub <code>gh</code> binary in a temp <code>bindir</code> and an empty temp <br>dir<br> <li> <code>run_hook</code> gains <code>gh_on_path</code> parameter to control PATH for deterministic <br>testing<br> <li> Added <code>test_not_gated_when_gh_not_installed</code> test verifying return code <br>0 when gh absent</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/531/files#diff-9051f5faa6652881da923aae1dae987602d750e6ff6be8f2cd19570c439b868c">+17/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document gh gate no-op behavior when gh is absent</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added changelog entry describing the new no-op behavior when <code>gh</code> is not <br>installed</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/531/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

