### PR TITLE
feat(openspec): include OpenSpec CLI and skills in sf-harness-upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `sjust sf-harness-upgrade` now also upgrades the OpenSpec CLI to the latest Homebrew release and refreshes the global OpenSpec skills and prompts: the OpenSpec Ansible block now carries the `ai-harness`/`ai-harness-sync` tags, so the upgrade reuses the existing `sf-openspec-configure` and `sf-openspec-install-global` recipes
 - The Claude `gh` gate is now a no-op when `gh` is not installed (not on `PATH`): rather than blocking to load the skill before a command that would only fail with "command not found", it lets the command run. No effect on machines that have `gh`.
 - The Claude `gh` gate now matches `gh` only when it is the command being run (start of the command, or after a `;`/`|`/`&`/newline separator, optionally preceded by env-var assignments), instead of anywhere in the command string. This prevents false-positive blocks when `gh` merely appears inside an argument, such as a commit message that mentions "gh".
 - Menu bar app binary now installs to user-owned `/opt/homebrew/bin/sparkdock-manager` instead of root-owned `/usr/local/bin`, so `sjust sparkdock-menubar-install` no longer needs sudo or a become password (build and LaunchAgent were already user-level)

--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -951,8 +951,19 @@
             - opencode_completion_output.rc == 0
 
     - name: Configure OpenSpec settings
-      tags: openspec
+      tags:
+        - openspec
+        - ai-harness
+        - ai-harness-sync
       block:
+        - name: Upgrade OpenSpec CLI to the latest release
+          community.general.homebrew:
+            name: openspec
+            state: latest
+            update_homebrew: false
+          become: false
+          when: "'openspec' in all_homebrew_packages"
+
         - name: Configure OpenSpec custom profile with all workflows
           command: "{{ dev_env_dir }}/sjust/sjust.sh sf-openspec-configure force"
           become: false

--- a/sjust/recipes/shared/01-ai-coding-harness.just
+++ b/sjust/recipes/shared/01-ai-coding-harness.just
@@ -13,7 +13,7 @@ sf-harness-sync $force="":
     fi
 
 # Upgrade the full AI coding harness: brew formulae, skills, agent profiles,
-# RTK hooks, and caveman. Runs via Ansible (no sudo required).
+# RTK hooks, caveman, and the OpenSpec CLI + global skills. Runs via Ansible (no sudo required).
 # Pass "force" or "--force" to overwrite locally modified resources.
 [group('ai-coding-harness')]
 sf-harness-upgrade $force="":

--- a/sjust/scripts/harness-status.sh
+++ b/sjust/scripts/harness-status.sh
@@ -393,14 +393,14 @@ main() {
         _render_commands_section
     fi
 
+    # Show OpenSpec spec-driven workflow status (CLI + global skills/prompts)
+    _render_openspec_section
+
     # Show skills + agent profiles (the other half of the harness)
     local agents_status="${SCRIPT_DIR}/../../bin/sparkdock-agents-status"
     if [[ -x "${agents_status}" ]]; then
         "${agents_status}"
     fi
-
-    # Show OpenSpec spec-driven workflow status (CLI + global skills/prompts)
-    _render_openspec_section
 }
 
 main "$@"


### PR DESCRIPTION
### **User description**
Tag the OpenSpec Ansible block with ai-harness/ai-harness-sync so sf-harness-upgrade upgrades the OpenSpec CLI (brew latest) and refreshes global skills via the existing configure/install-global recipes. Render the OpenSpec status section before the agents-status Manifest line.

Refs: sparkfabrik/sparkdock#515
Assisted-by: claude-code/claude-opus-4-8


___

### **PR Type**
Enhancement


___

### **Description**
- OpenSpec Ansible block now tagged with `ai-harness`/`ai-harness-sync` for upgrade inclusion

- Added task to upgrade OpenSpec CLI to latest Homebrew release during harness upgrade

- Reordered `_render_openspec_section` to appear before agents-status in harness status output

- Updated CHANGELOG and recipe comments to reflect OpenSpec inclusion in `sf-harness-upgrade`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["sf-harness-upgrade"] -- "triggers via ai-harness tag" --> B["OpenSpec Ansible Block"]
  B -- "upgrades" --> C["OpenSpec CLI (brew latest)"]
  B -- "runs" --> D["sf-openspec-configure"]
  B -- "runs" --> E["sf-openspec-install-global"]
  E -- "refreshes" --> F["Global Skills & Prompts"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base.yml</strong><dd><code>Tag OpenSpec block and add CLI upgrade task</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ansible/macos/macos/base.yml

<ul><li>Added <code>ai-harness</code> and <code>ai-harness-sync</code> tags to the OpenSpec Ansible <br>block so <code>sf-harness-upgrade</code> includes it<br> <li> Added new task to upgrade OpenSpec CLI to the latest Homebrew release <br>(<code>state: latest</code>)<br> <li> New upgrade task is conditional on <code>openspec</code> being present in installed <br>Homebrew packages</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/532/files#diff-35e06808caf91480daa0d30bc6b6a1e4c425376bb5d3196d021dca2357bdd621">+12/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>harness-status.sh</strong><dd><code>Reorder OpenSpec status before agents-status output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sjust/scripts/harness-status.sh

<ul><li>Moved <code>_render_openspec_section</code> call to appear before the agents-status <br>script invocation<br> <li> Removed the trailing blank line after the agents-status block</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/532/files#diff-0385e865d2c2d8de09dd0eed4ead8500922e7ab6663d75703c97d83c8c006dc3">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>01-ai-coding-harness.just</strong><dd><code>Update harness-upgrade recipe comment for OpenSpec</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sjust/recipes/shared/01-ai-coding-harness.just

<ul><li>Updated comment for <code>sf-harness-upgrade</code> recipe to mention OpenSpec CLI <br>and global skills inclusion</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/532/files#diff-c41922bc64cd013fbe5ce4bcabfe3e2d13eb52626539912e0f880c2d17f97b6f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document OpenSpec upgrade in CHANGELOG</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added changelog entry describing that <code>sf-harness-upgrade</code> now upgrades <br>OpenSpec CLI and refreshes global skills/prompts</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/532/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

