### PR TITLE
feat(packages): add generic install-once cask list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a `cask_install_once_packages` list in `config/packages/all-packages.yml` for Homebrew casks that should be installed only when absent and never force-reinstalled; each entry supports an optional `app` name so a copy installed outside Homebrew (e.g. downloaded from the web) is detected via its `.app` bundle and not reinstalled
 - Added an OpenSpec section to `sjust sf-harness-status` showing the `openspec` CLI version, the global `~/openspec` project state, and per-tool (claude/copilot/opencode) counts of installed `openspec-*` skills and `opsx` prompts; read-only, no-op when the CLI is absent
 - Added `sjust sf-openspec-install-global [tools]` recipe and Ansible task that install or update OpenSpec skills and prompt commands globally via a home `~/openspec` project; idempotent, defaults to the `claude` tool, runs during provisioning when the `openspec` CLI is available
 - Added a Claude Code `gh` skill gate: a sparkdock-managed `PreToolUse` hook (`sjust/scripts/claude-gh-gate.py`) that blocks the first `gh` command of a session until the `gh` skill is loaded via the Skill tool, then allows the rest of the session (per-session sentinel keyed by `session_id`). Scoped to `gh` only (the `glab` skill is in near-constant use and reliably loaded, so gating it would add friction with no payoff). Default-on (registered during provisioning, like the RTK/caveman hooks, on macOS and Linux); coexists with the RTK Bash hook since it only decides allow/deny. Manage it with `sjust claude-gh-gate-{enable,disable,info}`, and bypass at runtime with `SPARKDOCK_GH_GATE=0` for headless automation. Idempotent, atomic settings write with a timestamped backup, and it preserves all other hooks and settings.
@@ -89,6 +90,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Moved Docker Desktop, Google Chrome, VSCode Insiders, Slack, and Zoom from `cask_packages` to the new install-once handling, so they are installed once and never force-reinstalled on later provisioning runs; this replaces the three per-app skip blocks (Docker/Chrome/VSCode Insiders) with a single data-driven block and stops Chrome from being force-reinstalled (degrading the browser) while it is open
 - The OpenSpec CLI upgrade task now runs `brew update` first (`update_homebrew: true`) so `state: latest` resolves against current formula definitions instead of a possibly stale local index
 - `sjust sf-harness-upgrade` now also upgrades the OpenSpec CLI to the latest Homebrew release and refreshes the global OpenSpec skills and prompts: the OpenSpec Ansible block now carries the `ai-harness`/`ai-harness-sync` tags, so the upgrade reuses the existing `sf-openspec-configure` and `sf-openspec-install-global` recipes
 - The Claude `gh` gate is now a no-op when `gh` is not installed (not on `PATH`): rather than blocking to load the skill before a command that would only fail with "command not found", it lets the command run. No effect on machines that have `gh`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Moved Docker Desktop, Google Chrome, VSCode Insiders, Slack, and Zoom from `cask_packages` to the new install-once handling, so they are installed once and never force-reinstalled on later provisioning runs; this replaces the three per-app skip blocks (Docker/Chrome/VSCode Insiders) with a single data-driven block and stops Chrome from being force-reinstalled (degrading the browser) while it is open
+- Moved Docker Desktop, Google Chrome, VSCode (stable and Insiders), Slack, and Zoom from `cask_packages` to the new install-once handling, so they are installed once and never force-reinstalled on later provisioning runs; this replaces the three per-app skip blocks (Docker/Chrome/VSCode Insiders) with a single data-driven block and stops Chrome from being force-reinstalled (degrading the browser) while it is open
 - The OpenSpec CLI upgrade task now runs `brew update` first (`update_homebrew: true`) so `state: latest` resolves against current formula definitions instead of a possibly stale local index
 - `sjust sf-harness-upgrade` now also upgrades the OpenSpec CLI to the latest Homebrew release and refreshes the global OpenSpec skills and prompts: the OpenSpec Ansible block now carries the `ai-harness`/`ai-harness-sync` tags, so the upgrade reuses the existing `sf-openspec-configure` and `sf-openspec-install-global` recipes
 - The Claude `gh` gate is now a no-op when `gh` is not installed (not on `PATH`): rather than blocking to load the skill before a command that would only fail with "command not found", it lets the command run. No effect on machines that have `gh`.

--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -31,6 +31,7 @@
         - always
       set_fact:
         all_cask_packages: "{{ all_packages.cask_packages | default([]) }}"
+        all_cask_install_once: "{{ all_packages.cask_install_once_packages | default([]) }}"
         all_cask_latest_packages: "{{ all_packages.cask_latest_packages | default([]) }}"
         all_homebrew_packages: "{{ all_packages.homebrew_packages | default([]) }}"
         all_linked_packages: "{{ all_packages.linked_packages | default([]) }}"
@@ -129,44 +130,35 @@
       when: all_removed_homebrew | length > 0
       become: false
 
-    - name: Docker and container runtime installation
-      tags: [docker]
+    - name: Install-once casks (install if absent, never force-reinstall)
+      tags: [cask]
       block:
-        - name: Check if Docker Desktop is already installed
-          shell: brew list --cask docker-desktop >/dev/null 2>&1 && echo yes || echo no
-          register: docker_desktop_installed
+        - name: Detect already-installed install-once casks
+          shell: |
+            if brew list --cask "{{ item.name }}" >/dev/null 2>&1; then
+              echo yes
+            elif [ -n "{{ item.app | default('') }}" ] && { [ -d "/Applications/{{ item.app | default('') }}.app" ] || [ -d "{{ ansible_facts['env']['HOME'] }}/Applications/{{ item.app | default('') }}.app" ]; }; then
+              echo yes
+            else
+              echo no
+            fi
+          loop: "{{ all_cask_install_once }}"
+          register: install_once_checks
           changed_when: false
+          become: false
 
-        - name: Remove Docker Desktop from install list if already installed
+        - name: Build list of missing install-once casks
           set_fact:
-            all_cask_packages: "{{ all_cask_packages | difference(['docker-desktop']) }}"
-          when: "'docker-desktop' in all_cask_packages and docker_desktop_installed.stdout == 'yes'"
+            cask_install_once_to_install: "{{ install_once_checks.results | selectattr('stdout', 'equalto', 'no') | map(attribute='item.name') | list }}"
 
-    - name: Google Chrome installation
-      tags: [chrome]
-      block:
-        - name: Check if Google Chrome is already installed
-          shell: brew list --cask google-chrome >/dev/null 2>&1 && echo yes || echo no
-          register: google_chrome_installed
-          changed_when: false
-
-        - name: Remove Google Chrome from install list if already installed
-          set_fact:
-            all_cask_packages: "{{ all_cask_packages | difference(['google-chrome']) }}"
-          when: "'google-chrome' in all_cask_packages and google_chrome_installed.stdout == 'yes'"
-
-    - name: Visual Studio Code Insiders installation
-      tags: [vscode]
-      block:
-        - name: Check if Visual Studio Code Insiders is already installed
-          shell: brew list --cask visual-studio-code@insiders >/dev/null 2>&1 && echo yes || echo no
-          register: vscode_insiders_installed
-          changed_when: false
-
-        - name: Remove Visual Studio Code Insiders from install list if already installed
-          set_fact:
-            all_cask_packages: "{{ all_cask_packages | difference(['visual-studio-code@insiders']) }}"
-          when: "'visual-studio-code@insiders' in all_cask_packages and vscode_insiders_installed.stdout == 'yes'"
+        - name: Install missing install-once casks
+          community.general.homebrew_cask:
+            name: "{{ item }}"
+            state: present
+            sudo_password: "{{ ansible_become_pass | default(omit) }}"
+          loop: "{{ cask_install_once_to_install }}"
+          when: cask_install_once_to_install | length > 0
+          become: false
 
     - name: Transition GitHub Copilot CLI from npm to brew cask
       tags: copilot-cli

--- a/config/packages/all-packages.yml
+++ b/config/packages/all-packages.yml
@@ -17,7 +17,6 @@ cask_packages:
   - iterm2
   - maccy
   - cameracontroller
-  - visual-studio-code
   - monitorcontrol
   - claude
 
@@ -28,6 +27,8 @@ cask_install_once_packages:
     app: "Docker"
   - name: google-chrome
     app: "Google Chrome"
+  - name: visual-studio-code
+    app: "Visual Studio Code"
   - name: visual-studio-code@insiders
     app: "Visual Studio Code - Insiders"
   - name: slack

--- a/config/packages/all-packages.yml
+++ b/config/packages/all-packages.yml
@@ -5,7 +5,6 @@ taps:
 
 # Cloud Tools, Applications, and Fonts
 cask_packages:
-  - docker-desktop
   - google-cloud-sdk
   - applite
   - font-caskaydia-mono-nerd-font
@@ -13,18 +12,28 @@ cask_packages:
   - font-inconsolata-nerd-font
   - font-fira-code-nerd-font
   - font-jetbrains-mono-nerd-font
-  - google-chrome
   - ghostty
   - git-credential-manager
   - iterm2
   - maccy
   - cameracontroller
   - visual-studio-code
-  - visual-studio-code@insiders
-  - slack
-  - zoom
   - monitorcontrol
   - claude
+
+# Casks installed only if absent, never force-reinstalled (self-updating GUI apps).
+# `app` enables detection of installs made outside Homebrew (e.g. downloaded from the web).
+cask_install_once_packages:
+  - name: docker-desktop
+    app: "Docker"
+  - name: google-chrome
+    app: "Google Chrome"
+  - name: visual-studio-code@insiders
+    app: "Visual Studio Code - Insiders"
+  - name: slack
+    app: "Slack"
+  - name: zoom
+    app: "zoom.us"
 
 # Cask packages upgraded to latest on every provisioning run
 cask_latest_packages:


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

Replaces the Chrome-specific fix in #535 with a generic mechanism for Homebrew casks that should be installed only once and never force-reinstalled on later provisioning runs.

A new `cask_install_once_packages` list in `config/packages/all-packages.yml` names these casks. Each entry supports an optional `app` name, so a copy installed outside Homebrew (for example Chrome downloaded from Google's website) is detected via its `.app` bundle and left untouched, avoiding a conflicting `brew install --cask`.

## Background

Chrome was being force-reinstalled via Homebrew Cask on every provisioning run, degrading the browser while it was open. The repository already had three hardcoded, near-identical "skip if already installed" blocks for Docker Desktop, Chrome, and VSCode Insiders; each checked `brew list --cask X` and then dropped the cask from the force-install list. PR #535 patched only the Chrome block. This PR generalizes that pattern instead.

## Changes

- **`config/packages/all-packages.yml`**: add `cask_install_once_packages` (docker-desktop, google-chrome, visual-studio-code@insiders, slack, zoom), each with an optional `app` name; remove these casks from `cask_packages`.
- **`ansible/macos/macos/base.yml`**: replace the three per-app skip blocks with one data-driven block. It detects each cask (brew receipt OR `.app` bundle in `/Applications` or `~/Applications`) and installs only the missing ones with `state: present` (no `force`). The block is tagged `cask`, so it runs under `--tags cask` (the gap #535 fixed for Chrome). A new `all_cask_install_once` fact is added to the collect step.
- **`CHANGELOG.md`**: Added and Changed entries.

## Behavior

- Cask present in `/Applications` but installed outside Homebrew: detected, skipped, no conflicting `brew install`.
- Cask already installed via Homebrew: `state: present` is a no-op, never force-reinstalled.
- Cask absent: installed once.
- Adding a future install-once app is a single list entry, no playbook change.

## Verification

- `ansible-playbook ansible/macos.yml --syntax-check` passes.
- Detection logic validated against a provisioned machine: all five casks resolve to "already installed" and are excluded from the install list.
- `CHANGELOG.md` passes the Prettier format check.

Supersedes #535.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Introduce generic `cask_install_once_packages` list replacing hardcoded per-app skip blocks

- Detect casks via brew receipt OR `.app` bundle in `/Applications` or `~/Applications`

- Move Docker Desktop, Chrome, VSCode Insiders, Slack, Zoom to install-once handling

- Fix Chrome force-reinstall degrading browser state during provisioning


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["all-packages.yml\ncask_install_once_packages"] -- "loaded into" --> B["all_cask_install_once fact"]
  B -- "loop detect" --> C["Detect installed casks\n(brew list OR .app bundle)"]
  C -- "filter missing" --> D["cask_install_once_to_install"]
  D -- "state: present" --> E["homebrew_cask install\n(no force)"]
  F["Old: 3 hardcoded blocks\n(Docker/Chrome/VSCode)"] -- "replaced by" --> G["Single data-driven block\ntag: cask"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>all-packages.yml</strong><dd><code>Add cask_install_once_packages list with app detection support</code></dd></summary>
<hr>

config/packages/all-packages.yml

<ul><li>Removed <code>docker-desktop</code>, <code>google-chrome</code>, <code>visual-studio-code@insiders</code>, <br><code>slack</code>, and <code>zoom</code> from <code>cask_packages</code><br> <li> Added new <code>cask_install_once_packages</code> list with name/app pairs for each <br>moved cask<br> <li> Each entry includes an optional <code>app</code> field for detecting non-Homebrew <br>installs via <code>.app</code> bundle</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/536/files#diff-3ae984d019cd232f8832790630553e4e2af38f6fc97846eedf247fc19cc5b0dd">+14/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base.yml</strong><dd><code>Replace hardcoded skip blocks with generic install-once cask logic</code></dd></summary>
<hr>

ansible/macos/macos/base.yml

<ul><li>Added <code>all_cask_install_once</code> fact collected from <br><code>cask_install_once_packages</code><br> <li> Replaced three hardcoded per-app skip blocks (Docker, Chrome, VSCode <br>Insiders) with a single data-driven block tagged <code>cask</code><br> <li> New block detects each cask via brew receipt or <code>.app</code> bundle in <br><code>/Applications</code> or <code>~/Applications</code><br> <li> Installs only missing casks using <code>state: present</code> (no force-reinstall)</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/536/files#diff-35e06808caf91480daa0d30bc6b6a1e4c425376bb5d3196d021dca2357bdd621">+26/-34</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document install-once cask mechanism in changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added entry describing the new <code>cask_install_once_packages</code> list and its <br>behavior<br> <li> Added entry under Changed describing migration of <br>Docker/Chrome/VSCode/Slack/Zoom to install-once handling</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/536/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

