### PR TITLE
fix(menubar): retry verify and warm signature to survive endpoint-security exec kill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed the menubar provisioning aborting on the "Verify menu bar app works" task with `rc -9` (SIGKILL) on managed Macs: a freshly installed binary fires a first-exec authorization that an Endpoint Security agent (e.g. Mosyle) can deny under load; the install now clears the provenance xattr and re-applies the ad-hoc signature to warm the assessment, and the verify step retries until the agent's verdict caches
 - Fixed the managed Claude Code statusline dropping the weekly (`7d`) usage when Claude Code reports a fractional `seven_day.used_percentage` (e.g. `14.0000002`): the rate-limit percentages are now reduced to their integer part before the numeric check, the same way the context percentage already is. The `5h` value was unaffected only because it happened to be a whole number.
 - Fixed provisioning failing on machines that installed a package before its Homebrew tap was renamed (e.g. `skhd` pinned to `koekeishiya/formulae`): added a generic step that reinstalls any tap-qualified package whose install receipt no longer matches its declared tap, rebinding it; driven by the existing package list, no-op for fresh installs and already-correct packages
 - Fixed third-party Homebrew tap installs failing on Homebrew 6.x (`HOMEBREW_REQUIRE_TAP_TRUST`) by trusting each configured tap during provisioning; guarded to no-op on Homebrew < 6

--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -757,10 +757,26 @@
             mode: "0755"
             remote_src: true
 
+        - name: Clear provenance xattr and warm code signature
+          # A freshly written binary fires an ES_EVENT_TYPE_AUTH_EXEC event on its
+          # first exec; under load an Endpoint Security agent (e.g. Mosyle) can be
+          # slow to authorize, the kernel denies the exec and the verify task below
+          # dies with rc -9 (SIGKILL). Clearing the provenance xattr and re-applying
+          # the ad-hoc signature warms the assessment synchronously. See issue #537.
+          ansible.builtin.command: >-
+            /bin/sh -c 'xattr -c "{{ homebrew_brew_bin_path }}/sparkdock-manager";
+            codesign --force --sign - "{{ homebrew_brew_bin_path }}/sparkdock-manager"'
+          changed_when: false
+
         - name: Verify menu bar app works
           command: "{{ homebrew_brew_bin_path }}/sparkdock-manager --status"
           register: sparkdock_status
           changed_when: false
+          # Absorb a transient first-exec denial from an Endpoint Security agent
+          # until its verdict caches. See issue #537.
+          retries: 5
+          delay: 2
+          until: sparkdock_status.rc == 0
 
         - name: Display menu bar app status
           debug:

--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -761,11 +761,14 @@
           # A freshly written binary fires an ES_EVENT_TYPE_AUTH_EXEC event on its
           # first exec; under load an Endpoint Security agent (e.g. Mosyle) can be
           # slow to authorize, the kernel denies the exec and the verify task below
-          # dies with rc -9 (SIGKILL). Clearing the provenance xattr and re-applying
+          # dies with rc -9 (SIGKILL). Removing the provenance xattr and re-applying
           # the ad-hoc signature warms the assessment synchronously. See issue #537.
-          ansible.builtin.command: >-
-            /bin/sh -c 'xattr -c "{{ homebrew_brew_bin_path }}/sparkdock-manager";
-            codesign --force --sign - "{{ homebrew_brew_bin_path }}/sparkdock-manager"'
+          # The xattr removal is best-effort (the attribute may be absent), but the
+          # codesign step must succeed, so they are separate commands rather than a
+          # ';'-joined pipeline whose exit status would only reflect codesign.
+          ansible.builtin.shell: |
+            xattr -d com.apple.provenance "{{ homebrew_brew_bin_path }}/sparkdock-manager" 2>/dev/null || true
+            codesign --force --sign - "{{ homebrew_brew_bin_path }}/sparkdock-manager"
           changed_when: false
 
         - name: Verify menu bar app works


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @francescoben._

## Summary

The menubar provisioning block aborted on the **Verify menu bar app works** task (`ansible/macos/macos/base.yml`) with `rc -9` (SIGKILL) on managed Macs. The build and install succeeded, but the immediate `sparkdock-manager --status` verification was killed by the kernel after about 2 ms with no output.

The kill is a first-launch execution-authorization race, not a build problem. A freshly written binary fires an `ES_EVENT_TYPE_AUTH_EXEC` event on its first `exec()`, which blocks until the registered Endpoint Security client (on the fleet, the Mosyle detection extension) authorizes it. Under the load of a full provisioning run the verdict is slow, the exec is denied, and the process is killed. Once the verdict caches, later executions succeed. Full diagnosis is in #537.

## Changes

- Added a "Clear provenance xattr and warm code signature" step after the binary install. It runs `xattr -c` and re-applies the ad-hoc signature with `codesign --force --sign -`, warming the security assessment synchronously so the first verify is far less likely to be denied.
- Made the "Verify menu bar app works" step resilient with `retries: 5`, `delay: 2`, and `until: sparkdock_status.rc == 0`, so a transient first-exec denial is absorbed until the agent's verdict caches.
- Added a `CHANGELOG.md` entry under `### Fixed`.

The retry is the primary safety net; the xattr-clear and re-sign reduce the chance of even the first verify being denied.

## Testing

Verified on a Mosyle-managed Apple Silicon Mac (macOS Tahoe 26.5.1) by running the menubar provisioning on this branch. The verify task now passes instead of dying with `rc -9`.

Closes #537


___

### **PR Type**
Bug fix


___

### **Description**
- Add xattr clear and ad-hoc re-sign step after binary install to warm ES authorization

- Add retry logic (5 retries, 2s delay) to menubar verify task for transient SIGKILL

- Document fix in `CHANGELOG.md` for endpoint-security exec-kill race condition


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Install binary\n(copy task)"] -- "new inode +\nprovenance xattr" --> B["Clear xattr &\nre-sign (codesign)"]
  B -- "warmed ES verdict" --> C["Verify --status\n(retries: 5, delay: 2s)"]
  C -- "rc == 0" --> D["Success"]
  C -- "rc -9 (SIGKILL)\ntransient denial" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base.yml</strong><dd><code>Warm ES signature and retry verify to survive SIGKILL</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ansible/macos/macos/base.yml

<ul><li>Added "Clear provenance xattr and warm code signature" task after <br>binary install using <code>xattr -c</code> and <code>codesign --force --sign -</code><br> <li> Added <code>retries: 5</code>, <code>delay: 2</code>, and <code>until: sparkdock_status.rc == 0</code> to the <br>"Verify menu bar app works" task<br> <li> Both changes include inline comments referencing issue #537 explaining <br>the Endpoint Security race condition</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/538/files#diff-35e06808caf91480daa0d30bc6b6a1e4c425376bb5d3196d021dca2357bdd621">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document menubar SIGKILL fix in changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added entry under <code>### Fixed</code> describing the menubar <code>rc -9</code> SIGKILL fix<br> <li> Documents the root cause (Endpoint Security first-exec authorization <br>race) and the two-part fix (xattr clear + re-sign, plus retries)</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/538/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

