### PR TITLE
fix(shell): gate zoxide cd alias behind agent env markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Gated the zoxide `cd` alias behind the `CLAUDECODE`/`AI_AGENT` markers so AI coding agents get a literal `cd` (a missing relative path errors instead of frecency-jumping the agent's persistent working directory); interactive shells keep zoxide-backed `cd`, and `zd`/`z`/`zi` stay available everywhere
 - Fixed the menubar provisioning aborting on the "Verify menu bar app works" task with `rc -9` (SIGKILL) on managed Macs: a freshly installed binary fires a first-exec authorization that an Endpoint Security agent (e.g. Mosyle) can deny under load; the install now clears the provenance xattr and re-applies the ad-hoc signature to warm the assessment, and the verify step retries until the agent's verdict caches
 - Fixed the managed Claude Code statusline dropping the weekly (`7d`) usage when Claude Code reports a fractional `seven_day.used_percentage` (e.g. `14.0000002`): the rate-limit percentages are now reduced to their integer part before the numeric check, the same way the context percentage already is. The `5h` value was unaffected only because it happened to be a whole number.
 - Fixed provisioning failing on machines that installed a package before its Homebrew tap was renamed (e.g. `skhd` pinned to `koekeishiya/formulae`): added a generic step that reinstalls any tap-qualified package whose install receipt no longer matches its declared tap, rebinding it; driven by the existing package list, no-op for fresh installs and already-correct packages

--- a/config/shell/aliases.zsh
+++ b/config/shell/aliases.zsh
@@ -60,7 +60,6 @@ fi
 
 # zoxide integration with smart cd replacement
 if command_exists zoxide; then
-  alias cd="zd"
   zd() {
     if [ $# -eq 0 ]; then
       builtin cd ~ && return
@@ -70,6 +69,11 @@ if command_exists zoxide; then
       z "$@" && printf "\U000F17A9 " && pwd || echo "Error: Directory not found"
     fi
   }
+  # Keep cd literal under AI agents (Claude Code, etc.): zoxide frecency-jumps on a missing
+  # relative path instead of erroring, silently teleporting the agent's persistent cwd.
+  if [[ -z ${CLAUDECODE:-} && -z ${AI_AGENT:-} ]]; then
+    alias cd="zd"
+  fi
 fi
 
 # Modern replacements for classic commands


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

Closes #539

## Problem

The zoxide `cd` wrapper in `config/shell/aliases.zsh` aliases `cd` to `zd`. When a non-existent relative path is passed, `zd` falls through to a zoxide frecency jump instead of erroring. AI coding agents (Claude Code) run commands through a captured interactive-shell snapshot that inherits this alias, and the Bash tool persists the working directory between calls. A single `cd <name>` that does not resolve literally therefore teleports the agent into an unrelated high-frecency directory, and every later command runs there.

## Reproduction

```console
$ (cd /tmp && cd poc-drupal-rag-intelligence)
/home/paolo/webapps/sparkfabrik/ops/platform-team/sparkfabrik/labs/poc-drupal-rag-intelligence
```

No literal `poc-drupal-rag-intelligence` exists under `/tmp`, so zoxide jumped. A clone meant for one location landed in `.tmp/spark-gitlab-management` inside that directory.

## Fix

Gate only the `alias cd="zd"` line behind the agent environment markers `CLAUDECODE` and `AI_AGENT`, both exported by Claude Code. Interactive shells keep zoxide-backed `cd`; AI agents get a literal `cd` that errors on a missing path. The `zd`, `z`, and `zi` commands remain defined and usable everywhere.

## Verification

- `zsh -ic 'alias cd'` in a normal shell still reports `cd=zd`.
- After the snapshot regenerates, `cd /tmp && cd poc-drupal-rag-intelligence` reports `no such file or directory` with no teleport.


___

### **PR Type**
Bug fix


___

### **Description**
- Gate zoxide `cd` alias behind `CLAUDECODE`/`AI_AGENT` env markers

- AI agents now get literal `cd` that errors on missing paths

- Interactive shells retain zoxide-backed `cd` behavior unchanged

- Updated `CHANGELOG.md` with fix description


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Shell starts"] -- "zoxide exists" --> B["Define zd() function"]
  B -- "Check env markers" --> C{"CLAUDECODE or AI_AGENT set?"}
  C -- "Yes (AI agent)" --> D["cd = builtin cd (literal, errors on missing)"]
  C -- "No (interactive)" --> E["alias cd=zd (zoxide frecency jump)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>aliases.zsh</strong><dd><code>Gate zoxide cd alias behind AI agent environment markers</code>&nbsp; </dd></summary>
<hr>

config/shell/aliases.zsh

<ul><li>Moved <code>alias cd="zd"</code> to be conditional on absence of <code>CLAUDECODE</code> and <br><code>AI_AGENT</code> env vars<br> <li> Added explanatory comment about why AI agents need literal <code>cd</code> behavior<br> <li> <code>zd</code>, <code>z</code>, and <code>zi</code> commands remain available in all environments</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/540/files#diff-fe1e4df088c825fe14cb629660151d77d5debec9455646f03c762f2aefb8f03a">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document zoxide cd alias AI agent fix in changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added changelog entry describing the zoxide <code>cd</code> alias fix for AI agents</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/540/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

