### PR TITLE
refactor(ansible): replace ANSIBLE_BECOME_PASS env var with native --ask-become-pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Replaced the `ANSIBLE_BECOME_PASS` environment variable with Ansible's native `--ask-become-pass`, so the become password is held in memory instead of exported to the process environment (#541)
 - Moved Docker Desktop, Google Chrome, VSCode (stable and Insiders), Slack, and Zoom from `cask_packages` to the new install-once handling, so they are installed once and never force-reinstalled on later provisioning runs; this replaces the three per-app skip blocks (Docker/Chrome/VSCode Insiders) with a single data-driven block and stops Chrome from being force-reinstalled (degrading the browser) while it is open
 - The OpenSpec CLI upgrade task now runs `brew update` first (`update_homebrew: true`) so `state: latest` resolves against current formula definitions instead of a possibly stale local index
 - `sjust sf-harness-upgrade` now also upgrades the OpenSpec CLI to the latest Homebrew release and refreshes the global OpenSpec skills and prompts: the OpenSpec Ansible block now carries the `ai-harness`/`ai-harness-sync` tags, so the upgrade reuses the existing `sf-openspec-configure` and `sf-openspec-install-global` recipes

--- a/Justfile
+++ b/Justfile
@@ -10,30 +10,27 @@ run-ansible-playbook TAGS="all":
     #!/usr/bin/env bash
     set -euo pipefail
 
-    # Unset the password on exit
-    trap 'unset ANSIBLE_BECOME_PASS' EXIT
-
     TAGS={{TAGS}}
 
     # Ensure Python3 is installed and available at the expected location
     ./bin/sparkdock.macos ensure-python3
 
-    # Read password and save to env ANSIBLE_BECOME_PASS
-    # Check if we're running in CI (GitHub Actions sets these variables)
-    if [ -z "${CI:-}" ] && [ -z "${GITHUB_ACTIONS:-}" ]; then
-        read -rsp "Enter your password (for sudo access): " ANSIBLE_BECOME_PASS
-        export ANSIBLE_BECOME_PASS
-        echo
-    else
+    # Single shell-side CI-detection source of truth.
+    source ./bin/common/utils.sh
+
+    # CI runs with --become and no prompt; interactive runs prompt once via
+    # --ask-become-pass, which populates ansible_become_pass natively (no env var).
+    if is_ci_environment; then
         echo "Running in CI mode, skipping sudo password prompt"
-        export ANSIBLE_BECOME_PASS=""
+        BECOME_FLAG="--become"
+    else
+        BECOME_FLAG="--ask-become-pass"
     fi
 
-    # Pass the variable to ansible.
     if [ -z "${TAGS}" ]; then
-        ansible-playbook ./ansible/macos.yml -i ./ansible/inventory.ini -v
+        ansible-playbook ./ansible/macos.yml -i ./ansible/inventory.ini "${BECOME_FLAG}" -v
     else
-        ansible-playbook ./ansible/macos.yml -i ./ansible/inventory.ini --tags=${TAGS} -v
+        ansible-playbook ./ansible/macos.yml -i ./ansible/inventory.ini --tags=${TAGS} "${BECOME_FLAG}" -v
     fi
 
 # Run Python unit tests (stdlib unittest only; no third-party deps).

--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -10,7 +10,6 @@
     homebrew_prefix: "{{ (ansible_facts['machine'] == 'arm64') | ternary('/opt/homebrew', '/usr/local') }}"
     homebrew_install_path: "{{ homebrew_prefix }}/Homebrew"
     homebrew_brew_bin_path: "{{ homebrew_prefix }}/bin"
-    ansible_become_pass: "{{ lookup('env', 'ANSIBLE_BECOME_PASS') | default(omit, true) }}"
 
   tasks:
     - name: Check if running in non-interactive environment

--- a/bin/install.macos
+++ b/bin/install.macos
@@ -146,14 +146,8 @@ if [[ ! -f ./ansible/inventory.ini ]]; then
 EOF
 fi
 
-# Modify sparkdock.macos to use non-interactive mode if needed
-# it should exit if ansible fails.
+# Non-interactive cleanup of spurious files (part of the tart VM).
 if [[ "$NON_INTERACTIVE" == "true" ]]; then
-  # Make the sed replacement idempotent - only replace if the original pattern exists
-  if grep -q -- "--ask-become-pass" ./bin/sparkdock.macos; then
-    sed -i '' 's/--ask-become-pass/-e "ansible_become_password=" --become/g' ./bin/sparkdock.macos
-  fi
-  # Try to remove spurious files, they are part of the tart VM.
   # Yarn: /opt/homebrew/lib/node_modules/yarn/bin/yarn.js
   if [[ -e /opt/homebrew/lib/node_modules/yarn/bin/yarn.js ]]; then
     sudo rm -f /opt/homebrew/lib/node_modules/yarn/bin/yarn.js


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

The sudo become password was passed to Ansible through the `ANSIBLE_BECOME_PASS` environment variable, which exported the password into the process environment where it was visible to child processes and tools that inspect the environment. This change removes that path and uses Ansible's native become handling instead.

The `Justfile` `run-ansible-playbook` recipe now selects the become mode via `is_ci_environment` from `bin/common/utils.sh` (the single shell-side CI-detection source of truth): CI runs use `--become` with no prompt, while interactive runs use `--ask-become-pass`, which prompts once and populates `ansible_become_pass` natively in memory. This converges the `Justfile` onto the same `--ask-become-pass` route that the sjust recipes already use.

The play-level `ansible_become_pass` env lookup in `ansible/macos/macos/base.yml` is removed, and the now-dead `sed` rewrite of `bin/sparkdock.macos` in `bin/install.macos` is deleted (the `--ask-become-pass` rewrite it performed is no longer relevant once Ansible owns the prompt).

## Why

- The environment variable exposed the become password to the whole process environment; holding it in memory via `--ask-become-pass` narrows that exposure.
- Converging on `is_ci_environment` and `--ask-become-pass` removes a duplicate, divergent become path and aligns the `Justfile` with the sjust recipes.
- The `sed` block in `bin/install.macos` became dead code once the env-var path was removed.

## Changed files

- `CHANGELOG.md` — Unreleased entry describing the become-password change.
- `Justfile` — select `--become` (CI) or `--ask-become-pass` (interactive) via `is_ci_environment`; drop the `ANSIBLE_BECOME_PASS` read/export/trap.
- `ansible/macos/macos/base.yml` — remove the play-level `ansible_become_pass` env lookup.
- `bin/install.macos` — delete the dead `sed` rewrite of `bin/sparkdock.macos`.

## Follow-up

Open question for the reviewer, not a blocker: the `is_non_interactive` `set_fact` in `ansible/macos/macos/base.yml` was left unchanged and is still missing `CIRRUS_CI` relative to the condition set that `is_ci_environment` checks in `bin/common/utils.sh`. This means Cirrus CI runs could be treated as interactive by the Ansible fact even though the shell helper treats them as CI. It was left untouched per the implementation instruction not to modify that fact. Should it be aligned with `is_ci_environment` in a follow-up?

Closes #541


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Replace `ANSIBLE_BECOME_PASS` env var with native `--ask-become-pass` flag

- `Justfile` now uses `is_ci_environment` for single CI-detection source of truth

- Remove play-level env lookup for `ansible_become_pass` in `base.yml`

- Delete dead `sed` rewrite logic from `bin/install.macos`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Justfile run-ansible-playbook"] -- "source" --> B["bin/common/utils.sh\nis_ci_environment()"]
  B -- "CI=true" --> C["ansible-playbook\n--become"]
  B -- "interactive" --> D["ansible-playbook\n--ask-become-pass"]
  D -- "password in memory" --> E["ansible_become_pass\n(native Ansible var)"]
  F["ANSIBLE_BECOME_PASS\n(env var)"] -- "removed" --> G["❌ Deleted"]
  H["base.yml\nlookup('env', 'ANSIBLE_BECOME_PASS')"] -- "removed" --> G
  I["bin/install.macos\nsed rewrite logic"] -- "removed" --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document become password mechanism change in changelog</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added unreleased entry documenting the replacement of <br><code>ANSIBLE_BECOME_PASS</code> with <code>--ask-become-pass</code></ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/543/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Justfile</strong><dd><code>Replace env var become path with native --ask-become-pass</code></dd></summary>
<hr>

Justfile

<ul><li>Removed <code>trap</code> to unset <code>ANSIBLE_BECOME_PASS</code> on exit<br> <li> Removed <code>read -rsp</code> password prompt and <code>ANSIBLE_BECOME_PASS</code> export<br> <li> Added <code>source ./bin/common/utils.sh</code> to use <code>is_ci_environment</code> for CI <br>detection<br> <li> CI runs now use <code>--become</code> flag; interactive runs use <code>--ask-become-pass</code> <br>flag</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/543/files#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5c">+11/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>base.yml</strong><dd><code>Remove play-level ANSIBLE_BECOME_PASS env lookup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ansible/macos/macos/base.yml

<ul><li>Removed <code>ansible_become_pass</code> variable that read from <br><code>ANSIBLE_BECOME_PASS</code> environment variable via <code>lookup('env', ...)</code></ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/543/files#diff-35e06808caf91480daa0d30bc6b6a1e4c425376bb5d3196d021dca2357bdd621">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>install.macos</strong><dd><code>Delete dead sed rewrite of --ask-become-pass in install script</code></dd></summary>
<hr>

bin/install.macos

<ul><li>Removed dead <code>sed</code> rewrite logic that replaced <code>--ask-become-pass</code> with <code>-e </code><br><code>"ansible_become_password=" --become</code> in <code>sparkdock.macos</code><br> <li> Simplified the <code>NON_INTERACTIVE</code> block to only handle spurious file <br>cleanup</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/543/files#diff-3155e8fd815072a66aada172156d432cfb8ca8ec96f2b7fd939a3d3a422afabc">+1/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

