### PR TITLE
feat(tui): mark the hub as beta

### DIFF
--- a/src/tui/internal/ui/dashboard/dashboard.go
+++ b/src/tui/internal/ui/dashboard/dashboard.go
@@ -285,6 +285,7 @@ func (m Model) View() string {
 	}
 	var b strings.Builder
 	b.WriteString(" " + st.SparkS.Render(theme.Spark) + " " + st.Title.Render("sparkdock") +
+		" " + st.Amber.Render("beta") +
 		st.Dim.Render("   ·   dev environment manager") + "\n")
 	b.WriteString(st.Dim.Render(strings.Repeat("─", width)) + "\n")
 

--- a/src/tui/internal/ui/splash/splash.go
+++ b/src/tui/internal/ui/splash/splash.go
@@ -87,6 +87,7 @@ func (m Model) View() string {
 	block := lipgloss.JoinVertical(lipgloss.Center,
 		mark, "",
 		spark+"  "+st.Dim.Render("dev environment manager")+"  "+spark, "",
+		st.Amber.Render("beta")+st.Dim.Render(" · experimental"), "",
 		st.Dim.Render(m.ver.Short()), "",
 		st.Dim.Render("preparing… · click the logo · any key to skip"),
 	)


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

Mark the terminal hub as an experimental feature so users know it is beta.

- Dashboard header: an amber `beta` badge next to the `sparkdock` title (visible on every screen).
- Splash: a `beta · experimental` line under the tagline.

No behaviour change; purely a visible marker. Verified under a pseudo-TTY that the splash renders the badge.

## Related

Refs #542. Follows the hub merged in #544.


___

### **PR Type**
Enhancement


___

### **Description**
- Add amber `beta` badge next to title in dashboard header

- Add `beta · experimental` line on splash screen under tagline

- No behavior changes, purely visual beta markers


___

### Diagram Walkthrough


```mermaid
flowchart LR
  splash["Splash Screen"]
  dashboard["Dashboard Header"]
  amber["Amber 'beta' Badge"]
  betaLine["'beta · experimental' line"]

  amber -- "added to" --> dashboard
  betaLine -- "added to" --> splash
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dashboard.go</strong><dd><code>Add amber beta badge to dashboard header</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tui/internal/ui/dashboard/dashboard.go

<ul><li>Adds an amber-styled <code>beta</code> badge rendered next to the <code>sparkdock</code> title <br>in the dashboard header view</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/546/files#diff-c7bc7e7cbd45ac7d4383f156819a36778d321640701281dd9af89cfa73852342">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>splash.go</strong><dd><code>Add beta experimental line to splash screen</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tui/internal/ui/splash/splash.go

<ul><li>Adds a <code>beta · experimental</code> line below the tagline in the splash screen <br>vertical block layout</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/546/files#diff-ae74393a121251e3ab5ac3a4f1845cf56ab750cff018cd607eec5e187ef0872c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

