### PR TITLE
docs(tui): refresh README to match shipped hub

### DIFF
--- a/src/tui/README.md
+++ b/src/tui/README.md
@@ -1,68 +1,93 @@
 # sparkdock-tui
 
 Terminal hub for sparkdock (issue #542). Go + [bubbletea](https://github.com/charmbracelet/bubbletea),
-following the Elm architecture with a clean separation between pure core logic
-and injected side effects.
+following the Elm architecture (Model / Update / View): one immutable model, a
+pure `Update(msg) -> (model, Cmd)` transition, a pure `View() -> string`, and all
+side effects isolated in `Cmd`s that feed results back in as messages. This keeps
+a clean separation between pure core logic and injected side effects.
+
+It is an **opt-in, beta** front end: launched with `sparkdock tui`, never by bare
+`sparkdock` (which keeps its self-update and full-provisioning behaviour).
 
 ## Layout
 
 ```
 cmd/sparkdock-tui/      entrypoint: dispatch (TTY -> TUI, else headless), wiring
 internal/
-  feed/      pure parser for the @@PHASE/@@TASK/@@STAT/@@DONE callback protocol
+  feed/      pure parser + \r-aware decoder for the @@PHASE/@@TASK/@@STAT/@@DONE protocol
   theme/     all colours, glyphs, and lipgloss styles (single source of style)
   version/   git commit/branch/timestamps of /opt/sparkdock (no semver)
   status/    Checker interface + CmdChecker over sparkdock-check-updates / brew
-  runner/    Runner: exec ansible-playbook, stream feed.Events, cancel, become-env
-  ui/        shared page ids + navigation messages
-  ui/app/        root model: page router, size broadcast, input routing
-  ui/splash/     launch splash (block wordmark + spark glyph)
-  ui/dashboard/  flat grouped status/actions list
+  sysinfo/   Gatherer: model/serial/chip/memory/disk via system_profiler/sysctl/df/vm_stat
+  runner/    Runner: exec a command under a PTY, stream raw output, prompts, cancel
+  audio/     plays a short chime on logo click (afplay; SPARKDOCK_TUI_NO_AUDIO=1 disables)
+  ui/            shared page ids + navigation messages
+  ui/app/        root model: page router, size broadcast, input routing, run orchestration
+  ui/splash/     launch splash (block wordmark + spark glyph + beta badge)
+  ui/dashboard/  flat grouped status/actions list + system-info panel
+  ui/runview/    streaming run view; structured + terminal render strategies
+  ui/password/   masked become-password entry
+  ui/logview/    scrollable, copyable run log
 ```
 
 ## Design principles
 
-- **Pure core, injected effects.** `feed` is a pure function. `status`, `runner`,
-  and `version` take their side effects (command runner, command builder, git
-  func) as injected dependencies, so each is unit-tested without touching the
-  real environment.
-- **One style source.** Pages never hardcode colours; they call `theme.New()`.
-- **Decoupled pages.** Pages communicate only via `ui` messages; the `app`
-  router owns navigation. No page imports another.
+- **Pure core, injected effects.** `feed` is a pure parser. `status`, `sysinfo`,
+  `runner`, and `version` take their side effects (command runner, command
+  builder, git func) as injected dependencies, so each is unit-tested without
+  touching the real environment.
+- **One style source.** Pages never hardcode colours; they call `theme.Default()`.
+- **Decoupled pages.** Pages communicate only via `ui` messages; the `app` router
+  owns navigation. No page imports another.
 - **Status is never recomputed.** The dashboard reads `status.Checker`; freshness
   semantics live in the shell backend, shared with the menu bar app.
+- **The become password is never stored.** It is entered on a masked page and
+  written straight to the process PTY. It is never cached, never placed in the
+  environment, argv, or a file, and is asked for each time.
 
 ## Build & test
 
 ```sh
 go build ./...
-go test ./...
+go test ./... -count=1
+gofmt -l .      # must print nothing
+go vet ./...
 ```
+
+CI runs the same gates in `.github/workflows/test-tui.yml`.
 
 ## Pages
 
-- `splash` — launch wordmark + version.
-- `dashboard` — flat grouped status/actions list (live status).
-- `runview` — streaming run with a pinned statusline; cancel, retry, open log.
-- `password` — masked become-password entry (subprocess-scoped, session-cached).
-- `logview` — scrollable, copyable run log written to `~/.cache/sparkdock/last-run.log`.
-- `sjust` — recipe browser that runs the selected recipe through the runner.
+- `splash` — block wordmark, spark glyph, version, and a `beta` badge.
+- `dashboard` — flat grouped status/actions list with a system-info panel. Each
+  action shows its equivalent shell command (e.g. `Update everything` -> `$ sparkdock`,
+  `Upgrade Brew packages` -> `$ brew upgrade`, the `HTTP proxy` group -> `$ spark-http-proxy …`).
+- `runview` — streaming run with a pinned statusline; cancel, retry, open log. Two
+  render strategies behind one interface: **structured** decodes the sparkdock
+  callback into a line list + tally (ansible runs); **terminal** drives a VT
+  emulator for programs that redraw in place (e.g. `brew`).
+- `password` — masked become-password entry, written to the process PTY, never stored.
+- `logview` — scrollable, copyable run log (clipboard or file).
 
 The `app` router wires these together: it builds the `runner.Handle` per action,
-gates sudo actions behind the password page, caches the become password in
-memory for the session, and re-prompts on a sudo authentication failure.
+gates sudo actions behind the password page, writes the password to the PTY, and
+re-prompts on a sudo authentication failure.
 
 ## Install & run
 
-Built and installed during provisioning by the `tui` Ansible tag. Launch with
-`sparkdock tui` (it builds itself on first use, no sudo needed), or rebuild on
-demand with `sjust sparkdock-tui-install`. The Ansible stdout callback that
-drives the streaming view lives at `ansible/callback_plugins/sparkdock.py`.
+Built and installed during provisioning by the `tui` Ansible tag (`become: false`,
+no sudo). Launch with `sparkdock tui`: it builds the binary on first use and
+rebuilds whenever `src/tui` is newer than the installed binary, so a self-update
+that touched the TUI is picked up before launch. Rebuild on demand with
+`sjust sparkdock-tui-install`. The Ansible stdout callback that drives the
+structured view lives at `ansible/callback_plugins/sparkdock.py`.
+
+To run the binary against a dev checkout instead of `/opt/sparkdock`, set
+`SPARKDOCK_ROOT` to the repo root (the `sparkdock` entrypoint exports it for you);
+otherwise the callback plugin and status binaries resolve against `/opt/sparkdock`.
 
 ## Not yet wired
 
-- The `sparkdock` default command still provisions; flipping bare `sparkdock` to
-  the hub (with `sparkdock update` kept headless) and the in-hub self-update
-  remain a deliberate, separately-reviewed migration step.
-- Dashboard `proxy`, `device`, and Company actions, and `Update Sparkdock`, are
-  not yet handled (they no-op back to the dashboard).
+- The self-update action is hidden rather than shown as a dead button; the amber
+  status dot still signals a stale install, and bare `sparkdock` self-updates.
+- The headless delegate (`sparkdock-tui update` / non-TTY) is a stub.


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

The `src/tui/README.md` had drifted from what shipped. This rewrites it to match the merged hub.

Corrected:

- Password described as "session-cached" -> it is **never stored** (entered on a masked page, written to the PTY, re-prompted each time).
- `theme.New()` -> `theme.Default()`.
- Removed the `sjust` browser page (dropped in favour of HTTP-proxy actions).
- "Not yet wired" claimed a planned bare-`sparkdock` takeover; the hub is opt-in by design.

Added what was missing: opt-in beta launch, the full package layout (`audio`, `sysinfo`, `runview`, `password`, `logview`), CLI-equivalent action labels, the system-info panel, the structured/terminal render strategies, rebuild-on-stale, and `SPARKDOCK_ROOT` for dev checkouts.

## Related

Refs #542.


___

### **PR Type**
Documentation


___

### **Description**
- Rewrites `src/tui/README.md` to match the shipped hub

- Corrects password handling: "session-cached" → never stored, written to PTY

- Updates API references: `theme.New()` → `theme.Default()`

- Adds missing packages (`audio`, `sysinfo`, `runview`, `password`, `logview`) and features


___

### Diagram Walkthrough


```mermaid
flowchart LR
  old["Old README\n(stale descriptions)"] -- "corrected" --> new["Updated README"]
  new -- "password handling" --> pwd["Never stored\n(written to PTY)"]
  new -- "theme API" --> theme["theme.Default()"]
  new -- "package layout" --> pkgs["audio, sysinfo,\nrunview, password, logview"]
  new -- "launch model" --> launch["Opt-in via\n'sparkdock tui'"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Refresh TUI README to match shipped implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tui/README.md

<ul><li>Corrects password description from "session-cached" to never stored, <br>written directly to process PTY<br> <li> Updates <code>theme.New()</code> reference to <code>theme.Default()</code><br> <li> Removes <code>sjust</code> browser page entry; adds <code>audio</code>, <code>sysinfo</code>, <code>runview</code>, <br><code>password</code>, <code>logview</code> packages<br> <li> Adds opt-in beta launch description, system-info panel, <br>structured/terminal render strategies, rebuild-on-stale, and <br><code>SPARKDOCK_ROOT</code> dev env var<br> <li> Clarifies "Not yet wired" section: self-update hidden, headless <br>delegate is a stub</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/547/files#diff-c2fd6be6ab30aed4571ef08fc2c9be50313d3ba398b77b95ae835430e2dfd75c">+58/-33</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

