### PR TITLE
feat(tui): flare the splash logo on click, synced to the sound

### DIFF
--- a/src/tui/internal/theme/theme.go
+++ b/src/tui/internal/theme/theme.go
@@ -2,7 +2,12 @@
 // TUI so the visual language lives in one place and pages stay free of literals.
 package theme
 
-import "github.com/charmbracelet/lipgloss"
+import (
+	"fmt"
+	"math"
+
+	"github.com/charmbracelet/lipgloss"
+)
 
 // Brand and semantic colours. 256-colour codes keep output readable on the
 // common terminals sparkdock targets; truecolor terminals render them faithfully.
@@ -16,6 +21,38 @@ var (
 	Grey    = lipgloss.Color("240") // dim / secondary
 	FgLight = lipgloss.Color("15")  // selected foreground
 )
+
+// Glow base RGB for the logo flare. The wordmark base approximates the brand
+// purple (256-colour 99) and the spark base the orange glyph (208); both are
+// interpolated toward white at the flare's peak. Truecolor terminals render the
+// ramp smoothly; lipgloss downsamples it on 256-colour terminals.
+var (
+	TitleGlowBase = [3]int{0x87, 0x5F, 0xFF}
+	SparkGlowBase = [3]int{0xFF, 0x87, 0x00}
+)
+
+// GlowFactor maps an animation phase in [0,1] to a brightness factor in [0,1],
+// mirroring the logo sound's envelope: a fast attack to a white-hot peak, then
+// an exponential decay back to the base colour. Outside (0,1) it is 0.
+func GlowFactor(phase float64) float64 {
+	if phase <= 0 || phase >= 1 {
+		return 0
+	}
+	const attack = 0.18
+	if phase < attack {
+		return phase / attack
+	}
+	return math.Exp(-3.5 * (phase - attack) / (1 - attack))
+}
+
+// Glow interpolates a base RGB colour toward white by factor f (clamped to
+// [0,1]) and returns it as a truecolor hex value. f=0 is the base colour, f=1 is
+// white.
+func Glow(base [3]int, f float64) lipgloss.Color {
+	f = math.Max(0, math.Min(1, f))
+	mix := func(c int) int { return c + int(math.Round(float64(255-c)*f)) }
+	return lipgloss.Color(fmt.Sprintf("#%02X%02X%02X", mix(base[0]), mix(base[1]), mix(base[2])))
+}
 
 // Glyphs shared across views.
 const (

--- a/src/tui/internal/theme/theme_test.go
+++ b/src/tui/internal/theme/theme_test.go
@@ -1,0 +1,46 @@
+package theme
+
+import "testing"
+
+func TestGlowFactorEndpointsAreZero(t *testing.T) {
+	for _, phase := range []float64{-0.5, 0, 1, 1.5} {
+		if got := GlowFactor(phase); got != 0 {
+			t.Errorf("GlowFactor(%v) = %v, want 0", phase, got)
+		}
+	}
+}
+
+func TestGlowFactorPeaksAtAttack(t *testing.T) {
+	// The attack reaches full brightness (1.0) at phase 0.18; the decay only
+	// falls from there, so 0.18 is the maximum over (0,1).
+	peak := GlowFactor(0.18)
+	if peak < 0.99 || peak > 1.01 {
+		t.Fatalf("GlowFactor(0.18) = %v, want ~1", peak)
+	}
+	if mid := GlowFactor(0.6); mid >= peak {
+		t.Errorf("decay GlowFactor(0.6) = %v should be below peak %v", mid, peak)
+	}
+	if early := GlowFactor(0.09); early <= 0 || early >= peak {
+		t.Errorf("attack GlowFactor(0.09) = %v should be between 0 and peak", early)
+	}
+}
+
+func TestGlowZeroIsBaseFullIsWhite(t *testing.T) {
+	base := [3]int{0xFF, 0x87, 0x00}
+	if got := Glow(base, 0); got != "#FF8700" {
+		t.Errorf("Glow(base, 0) = %q, want #FF8700", got)
+	}
+	if got := Glow(base, 1); got != "#FFFFFF" {
+		t.Errorf("Glow(base, 1) = %q, want #FFFFFF", got)
+	}
+}
+
+func TestGlowClampsOutOfRange(t *testing.T) {
+	base := [3]int{0x10, 0x20, 0x30}
+	if got := Glow(base, -1); got != "#102030" {
+		t.Errorf("Glow(base, -1) = %q, want base #102030", got)
+	}
+	if got := Glow(base, 2); got != "#FFFFFF" {
+		t.Errorf("Glow(base, 2) = %q, want white #FFFFFF", got)
+	}
+}

--- a/src/tui/internal/ui/splash/splash.go
+++ b/src/tui/internal/ui/splash/splash.go
@@ -30,16 +30,31 @@ const (
 	maxShow = 8 * time.Second
 )
 
+// Glow timing: a click flares the logo for glowDur, redrawn every glowFrame,
+// matching the logo sound's envelope.
+const (
+	glowDur   = 700 * time.Millisecond
+	glowFrame = 45 * time.Millisecond
+)
+
 // MinElapsedMsg fires once the minimum splash time has passed.
 type MinElapsedMsg struct{}
 
 // TimeoutMsg fires at the maximum splash time, forcing a hand-off.
 type TimeoutMsg struct{}
 
+// glowTickMsg drives a frame of the logo flare; its time is compared to the
+// flare's start to derive the animation phase.
+type glowTickMsg time.Time
+
 // Model is the splash page.
 type Model struct {
 	width, height int
 	ver           version.Info
+
+	glowStart  time.Time
+	glowing    bool
+	glowFactor float64
 }
 
 // New returns a splash for the given version info.
@@ -65,9 +80,30 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	case tea.MouseMsg:
 		if msg.Action == tea.MouseActionPress {
 			audio.Play() // click the logo to hear it
+			m.glowStart = time.Now()
+			m.glowing = true
+			m.glowFactor = 0
+			return m, glowTick()
 		}
+	case glowTickMsg:
+		if !m.glowing {
+			return m, nil
+		}
+		phase := float64(time.Time(msg).Sub(m.glowStart)) / float64(glowDur)
+		if phase >= 1 {
+			m.glowing = false
+			m.glowFactor = 0
+			return m, nil
+		}
+		m.glowFactor = theme.GlowFactor(phase)
+		return m, glowTick()
 	}
 	return m, nil
+}
+
+// glowTick schedules the next flare frame.
+func glowTick() tea.Cmd {
+	return tea.Tick(glowFrame, func(t time.Time) tea.Msg { return glowTickMsg(t) })
 }
 
 // View renders the centred splash.
@@ -77,13 +113,18 @@ func (m Model) View() string {
 	if w == 0 {
 		w, h = 80, 24
 	}
+	markStyle, sparkStyle := st.Title, st.SparkS
+	if m.glowing {
+		markStyle = markStyle.Foreground(theme.Glow(theme.TitleGlowBase, m.glowFactor))
+		sparkStyle = sparkStyle.Foreground(theme.Glow(theme.SparkGlowBase, m.glowFactor))
+	}
 	var mark string
 	if w >= minWidth {
-		mark = st.Title.Render(strings.TrimRight(wordmark, "\n"))
+		mark = markStyle.Render(strings.TrimRight(wordmark, "\n"))
 	} else {
-		mark = st.Title.Render("S P A R K D O C K")
+		mark = markStyle.Render("S P A R K D O C K")
 	}
-	spark := st.SparkS.Render(theme.Spark)
+	spark := sparkStyle.Render(theme.Spark)
 	block := lipgloss.JoinVertical(lipgloss.Center,
 		mark, "",
 		spark+"  "+st.Dim.Render("dev environment manager")+"  "+spark, "",


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

Clicking the splash logo now flares the wordmark and spark glyph: a brightness ramp from the base colour to white-hot and back over 700 ms, matching the `spark-zap` sound's envelope. Audio and light flare together.

## How

- `theme.GlowFactor(phase)` — the attack/decay envelope (fast rise to a white-hot peak at ~18%, exponential decay back to 0). Pure, unit-tested.
- `theme.Glow(base, f)` — interpolate a base RGB toward white by factor `f`, returned as truecolor hex. Pure, unit-tested.
- The splash stores a flare start on click and drives frames with a `tea.Tick` loop (~45 ms), applying the ramped colour to the wordmark and spark in `View`.

## Notes

- Truecolor terminals render the ramp smoothly; lipgloss downsamples it on 256-colour terminals.
- Scoped to the splash, where the mouse is enabled (it is deliberately disabled on the dashboard for native text-copy), so this does not affect copy behaviour.
- Hard to verify in CI (it is an animation); the envelope and colour maths are covered by `theme` unit tests, and the full suite plus `go vet` are green.

## Related

Refs #542.


___

### **PR Type**
Enhancement


___

### **Description**
- Add logo flare animation on splash screen click

- Implement `GlowFactor` (attack/decay envelope) and `Glow` (RGB interpolation) in theme package

- Drive flare frames with `tea.Tick` loop at ~45ms intervals over 700ms duration

- Add unit tests for glow envelope and colour interpolation functions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  click["Mouse Click on Logo"]
  audio["audio.Play()"]
  glowStart["Set glowStart + glowing=true"]
  glowTick["glowTick() tea.Cmd"]
  glowTickMsg["glowTickMsg received"]
  phase["Compute phase from elapsed time"]
  GlowFactor["theme.GlowFactor(phase)"]
  Glow["theme.Glow(base, factor)"]
  View["Apply color to markStyle + sparkStyle"]

  click -- "triggers" --> audio
  click -- "triggers" --> glowStart
  glowStart -- "schedules" --> glowTick
  glowTick -- "fires" --> glowTickMsg
  glowTickMsg -- "computes" --> phase
  phase -- "feeds" --> GlowFactor
  GlowFactor -- "factor" --> Glow
  Glow -- "truecolor hex" --> View
  View -- "re-schedules if phase < 1" --> glowTick
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>theme.go</strong><dd><code>Add glow envelope and colour interpolation to theme</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tui/internal/theme/theme.go

<ul><li>Add <code>TitleGlowBase</code> and <code>SparkGlowBase</code> RGB base colour constants for the <br>flare<br> <li> Add <code>GlowFactor(phase)</code> function implementing <br>fast-attack/exponential-decay envelope<br> <li> Add <code>Glow(base, f)</code> function interpolating an RGB colour toward white by <br>factor <code>f</code><br> <li> Import <code>fmt</code> and <code>math</code> packages to support new functions</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/549/files#diff-dee2f8dee589fda854573257fe964a78ee4cc3d03879a1d6e03ba2d2e5122188">+38/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>splash.go</strong><dd><code>Drive logo flare animation from mouse click in splash</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tui/internal/ui/splash/splash.go

<ul><li>Add <code>glowDur</code> (700ms) and <code>glowFrame</code> (45ms) timing constants for the <br>flare animation<br> <li> Add <code>glowTickMsg</code> type to drive per-frame updates<br> <li> Add <code>glowStart</code>, <code>glowing</code>, and <code>glowFactor</code> fields to <code>Model</code><br> <li> On mouse press, start the flare and schedule the first tick via <br><code>glowTick()</code><br> <li> On <code>glowTickMsg</code>, compute animation phase, update <code>glowFactor</code>, and <br>reschedule or stop<br> <li> In <code>View</code>, apply <code>theme.Glow</code> to wordmark and spark styles when <code>glowing</code> is <br>true</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/549/files#diff-ae74393a121251e3ab5ac3a4f1845cf56ab750cff018cd607eec5e187ef0872c">+44/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>theme_test.go</strong><dd><code>Unit tests for GlowFactor and Glow functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tui/internal/theme/theme_test.go

<ul><li>New test file for theme package<br> <li> Tests that <code>GlowFactor</code> returns 0 at and outside boundaries<br> <li> Tests that <code>GlowFactor</code> peaks at the attack phase (~0.18) and decays <br>afterward<br> <li> Tests that <code>Glow</code> returns base colour at f=0, white at f=1, and clamps <br>out-of-range values</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/549/files#diff-760c5bfb5e27a6b6f61439d5b52e9b820b09718f8e0d73c5174d21df2d91feda">+46/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

