### PR TITLE
refactor(tui): tidy splash glow — accurate doc, single tick loop, tests

### DIFF
--- a/src/tui/internal/ui/splash/splash.go
+++ b/src/tui/internal/ui/splash/splash.go
@@ -71,8 +71,9 @@ func (m Model) Init() tea.Cmd {
 // SetSize updates the render dimensions.
 func (m *Model) SetSize(w, h int) { m.width, m.height = w, h }
 
-// Update plays the startup sound when the logo is clicked, and dismisses on any
-// key or click (the timer dismiss is handled by the app router).
+// Update dismisses on any key, and on a logo click plays the startup sound and
+// starts the flare. A click never dismisses; the timer dismiss is handled by the
+// app router.
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
@@ -80,9 +81,16 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	case tea.MouseMsg:
 		if msg.Action == tea.MouseActionPress {
 			audio.Play() // click the logo to hear it
+			wasGlowing := m.glowing
 			m.glowStart = time.Now()
 			m.glowing = true
 			m.glowFactor = 0
+			if wasGlowing {
+				// A flare is already running; restart its envelope (new
+				// glowStart) and let the single tick loop carry it, rather than
+				// spawning a second concurrent loop.
+				return m, nil
+			}
 			return m, glowTick()
 		}
 	case glowTickMsg:

--- a/src/tui/internal/ui/splash/splash_test.go
+++ b/src/tui/internal/ui/splash/splash_test.go
@@ -1,0 +1,56 @@
+package splash
+
+import (
+	"testing"
+	"time"
+)
+
+// A tick mid-flare advances the brightness and keeps the loop running.
+func TestGlowTickMidFlareAdvancesAndReschedules(t *testing.T) {
+	t0 := time.Unix(1000, 0)
+	m := Model{glowing: true, glowStart: t0}
+
+	m, cmd := m.Update(glowTickMsg(t0.Add(350 * time.Millisecond)))
+
+	if !m.glowing {
+		t.Fatal("flare should still be running mid-envelope")
+	}
+	if m.glowFactor <= 0 {
+		t.Errorf("glowFactor = %v, want > 0 mid-flare", m.glowFactor)
+	}
+	if cmd == nil {
+		t.Error("expected a reschedule command while glowing")
+	}
+}
+
+// A tick past the duration ends the flare and stops the loop.
+func TestGlowTickPastDurationEnds(t *testing.T) {
+	t0 := time.Unix(1000, 0)
+	m := Model{glowing: true, glowStart: t0}
+
+	m, cmd := m.Update(glowTickMsg(t0.Add(glowDur + 50*time.Millisecond)))
+
+	if m.glowing {
+		t.Error("flare should have ended past glowDur")
+	}
+	if m.glowFactor != 0 {
+		t.Errorf("glowFactor = %v, want 0 after the flare", m.glowFactor)
+	}
+	if cmd != nil {
+		t.Error("expected no further reschedule after the flare ends")
+	}
+}
+
+// A stray tick after the flare ended is ignored and does not restart the loop.
+func TestGlowTickWhenNotGlowingIsNoop(t *testing.T) {
+	m := Model{glowing: false}
+
+	m, cmd := m.Update(glowTickMsg(time.Unix(2000, 0)))
+
+	if m.glowing {
+		t.Error("a tick must not start a flare on its own")
+	}
+	if cmd != nil {
+		t.Error("a tick while not glowing should not reschedule")
+	}
+}


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

Fresh-eyes review fixes for the logo flare (merged in #549).

- **Doc accuracy**: the `Update` comment claimed a click dismisses the splash; it does not. Only a key dismisses; a click flares and plays the sound. Corrected.
- **Single tick loop**: rapid re-clicks used to spawn a concurrent `tea.Tick` loop per click. Now a re-click while glowing just restarts the envelope (resets `glowStart`) and lets the one existing loop carry it. Bounded, no wasted frames, click-to-restart preserved.
- **Tests**: added splash tests for the glow state machine (advances + reschedules mid-flare, ends past `glowDur`, stray tick while not glowing is a no-op). These drive `glowTickMsg` with synthetic times, so they are deterministic and need no clock injection.

No user-visible behaviour change beyond the rapid-click tidy. Build, vet, and tests green.

## Related

Refs #542. Follows #549.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Fix doc comment: click flares logo, never dismisses splash

- Prevent concurrent tick loops on rapid re-clicks (restart envelope instead)

- Add deterministic splash glow state machine tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  click["Mouse Click on Logo"]
  wasGlowing["wasGlowing check"]
  restart["Restart envelope (glowStart reset)"]
  newLoop["Start new glowTick loop"]
  singleLoop["Single tick loop continues"]
  glowTickMsg["glowTickMsg received"]
  end["Flare ends (glowing=false)"]

  click -- "sets glowing=true" --> wasGlowing
  wasGlowing -- "was already glowing" --> restart
  restart -- "returns nil cmd" --> singleLoop
  wasGlowing -- "was not glowing" --> newLoop
  newLoop -- "fires" --> glowTickMsg
  singleLoop -- "fires" --> glowTickMsg
  glowTickMsg -- "past glowDur" --> end
  glowTickMsg -- "mid-flare" --> singleLoop
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>splash.go</strong><dd><code>Fix rapid re-click spawning concurrent glow tick loops</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tui/internal/ui/splash/splash.go

<ul><li>Correct <code>Update</code> doc comment: click flares and plays sound but never <br>dismisses; only a key dismisses<br> <li> Prevent spawning a second concurrent tick loop on rapid re-clicks by <br>checking <code>wasGlowing</code> and returning <code>nil</code> cmd when a loop is already <br>running<br> <li> Restart the glow envelope (<code>glowStart</code>) on re-click so the animation <br>resets without a new loop</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/550/files#diff-ae74393a121251e3ab5ac3a4f1845cf56ab750cff018cd607eec5e187ef0872c">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>splash_test.go</strong><dd><code>Add deterministic splash glow state machine tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tui/internal/ui/splash/splash_test.go

<ul><li>New test file for the splash glow state machine<br> <li> Tests that a mid-flare tick advances <code>glowFactor</code> and reschedules<br> <li> Tests that a tick past <code>glowDur</code> ends the flare and stops the loop<br> <li> Tests that a stray tick while not glowing is a no-op</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/550/files#diff-b2d8dd7875f136622a0379a0cc4a7feead7cbc97dfa7c7882e40f0db2ac8667f">+56/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

