### PR TITLE
feat(tui): show cached memory in the system-info panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added cached (reclaimable) memory to the `sparkdock tui` system-info panel, shown beside free memory (e.g. `8 GB free · 16 GB cached / 48 GB`), the way Activity Monitor distinguishes free from "Cached Files"
 - Added a `beta` badge to the `sparkdock tui` splash and header, plus a logo flourish: clicking the splash logo plays an original synthesized chime and flares the wordmark and spark glyph with a brightness ramp synced to the sound
 - Added `sparkdock tui`, an opt-in terminal hub (Go/bubbletea) mirroring the menu bar app: a status dashboard with a system-info panel, and a streaming view (pinned statusline, masked never-cached sudo entry, cancel, retry, copyable log) for provisioning, `brew upgrade`, AI-harness sync, and HTTP-proxy actions, each labelled with its equivalent shell command. Built via the `tui` Ansible tag; bare `sparkdock` is unchanged
 - Added a `cask_install_once_packages` list in `config/packages/all-packages.yml` for Homebrew casks that should be installed only when absent and never force-reinstalled; each entry supports an optional `app` name so a copy installed outside Homebrew (e.g. downloaded from the web) is detected via its `.app` bundle and not reinstalled

--- a/src/tui/internal/sysinfo/sysinfo.go
+++ b/src/tui/internal/sysinfo/sysinfo.go
@@ -22,6 +22,7 @@ type Info struct {
 	GPUCores  int
 	MemTotal  uint64
 	MemFree   uint64
+	MemCached uint64
 	DiskTotal uint64
 	DiskFree  uint64
 	OS        string
@@ -41,7 +42,7 @@ func (g Gatherer) Gather(ctx context.Context) Info {
 	if memsize := parseUint(g.Run(ctx, "sysctl", "-n", "hw.memsize").Stdout); memsize > 0 {
 		hw.MemTotal = memsize
 	}
-	hw.MemFree = parseVMStatFree(g.Run(ctx, "vm_stat").Stdout)
+	hw.MemFree, hw.MemCached = parseVMStat(g.Run(ctx, "vm_stat").Stdout)
 	hw.DiskTotal, hw.DiskFree = parseDF(g.Run(ctx, "df", "-k", "/").Stdout)
 	hw.OS = strings.TrimSpace(g.Run(ctx, "sw_vers", "-productVersion").Stdout)
 	return hw
@@ -95,26 +96,33 @@ func parseHardware(out string) Info {
 	return info
 }
 
-// parseVMStatFree returns free + inactive memory in bytes from `vm_stat` output.
-func parseVMStatFree(out string) uint64 {
+// parseVMStat returns (free, cached) memory in bytes from `vm_stat` output.
+// free is immediately-available memory (free + speculative pages); cached is the
+// reclaimable file cache (inactive + purgeable pages), shown the way Activity
+// Monitor distinguishes free memory from "Cached Files".
+func parseVMStat(out string) (free, cached uint64) {
 	pageSize := uint64(4096)
 	if i := strings.Index(out, "page size of "); i >= 0 {
 		if n := leadingInt(out[i+len("page size of "):]); n > 0 {
 			pageSize = uint64(n)
 		}
 	}
-	var pages uint64
+	var freePages, cachedPages uint64
 	for _, raw := range strings.Split(out, "\n") {
 		line := strings.TrimSpace(raw)
 		key, val, ok := strings.Cut(line, ":")
 		if !ok {
 			continue
 		}
-		if key == "Pages free" || key == "Pages inactive" || key == "Pages speculative" {
-			pages += uint64(leadingInt(strings.TrimSpace(val)))
+		n := uint64(leadingInt(strings.TrimSpace(val)))
+		switch key {
+		case "Pages free", "Pages speculative":
+			freePages += n
+		case "Pages inactive", "Pages purgeable":
+			cachedPages += n
 		}
 	}
-	return pages * pageSize
+	return freePages * pageSize, cachedPages * pageSize
 }
 
 // parseDF returns (total, free) bytes for the root filesystem from `df -k /`.

--- a/src/tui/internal/sysinfo/sysinfo_test.go
+++ b/src/tui/internal/sysinfo/sysinfo_test.go
@@ -99,7 +99,7 @@ func TestGather_UsesInjectedRunner(t *testing.T) {
 		case "sysctl":
 			return status.CommandResult{Stdout: "38654705664\n"} // 36 GiB
 		case "vm_stat":
-			return status.CommandResult{Stdout: "Mach Virtual Memory Statistics: (page size of 16384 bytes)\nPages free: 1000.\nPages inactive: 0.\n"}
+			return status.CommandResult{Stdout: "Mach Virtual Memory Statistics: (page size of 16384 bytes)\nPages free: 1000.\nPages inactive: 500.\n"}
 		case "df":
 			return status.CommandResult{Stdout: "Filesystem 1024-blocks Used Available Capacity Mounted\n/dev/disk3 100 40 60 40% /\n"}
 		case "sw_vers":
@@ -116,6 +116,9 @@ func TestGather_UsesInjectedRunner(t *testing.T) {
 	}
 	if got.MemFree != 1000*16384 {
 		t.Errorf("MemFree = %d", got.MemFree)
+	}
+	if got.MemCached != 500*16384 {
+		t.Errorf("MemCached = %d", got.MemCached)
 	}
 	if got.DiskFree != 60*1024 {
 		t.Errorf("DiskFree = %d", got.DiskFree)

--- a/src/tui/internal/sysinfo/sysinfo_test.go
+++ b/src/tui/internal/sysinfo/sysinfo_test.go
@@ -47,17 +47,22 @@ func TestParseHardware(t *testing.T) {
 	}
 }
 
-func TestParseVMStatFree(t *testing.T) {
+func TestParseVMStat(t *testing.T) {
 	out := `Mach Virtual Memory Statistics: (page size of 16384 bytes)
 Pages free:                          1000.
 Pages active:                        9000.
 Pages inactive:                      2000.
 Pages speculative:                    500.
+Pages purgeable:                      300.
 `
-	// (1000 + 2000 + 500) * 16384
-	want := uint64(3500) * 16384
-	if got := parseVMStatFree(out); got != want {
-		t.Errorf("free = %d, want %d", got, want)
+	free, cached := parseVMStat(out)
+	// free + speculative
+	if want := uint64(1500) * 16384; free != want {
+		t.Errorf("free = %d, want %d", free, want)
+	}
+	// inactive + purgeable
+	if want := uint64(2300) * 16384; cached != want {
+		t.Errorf("cached = %d, want %d", cached, want)
 	}
 }
 

--- a/src/tui/internal/ui/dashboard/dashboard.go
+++ b/src/tui/internal/ui/dashboard/dashboard.go
@@ -253,7 +253,11 @@ func (m Model) sysInfoBlock(st theme.Styles) string {
 		lines = append(lines, row("Chip", chip))
 	}
 	if s.MemTotal > 0 {
-		lines = append(lines, row("Memory", fmt.Sprintf("%s free / %s", gb(s.MemFree), gb(s.MemTotal))))
+		mem := fmt.Sprintf("%s free / %s", gb(s.MemFree), gb(s.MemTotal))
+		if s.MemCached > 0 {
+			mem = fmt.Sprintf("%s free · %s cached / %s", gb(s.MemFree), gb(s.MemCached), gb(s.MemTotal))
+		}
+		lines = append(lines, row("Memory", mem))
 	}
 	if s.DiskTotal > 0 {
 		lines = append(lines, row("Disk", fmt.Sprintf("%s free / %s", gb(s.DiskFree), gb(s.DiskTotal))))


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

The system-info panel's Memory line now shows cached (reclaimable) memory beside free, e.g. `8 GB free · 16 GB cached / 48 GB`, the way Activity Monitor distinguishes free memory from "Cached Files".

- `free` = immediately-available memory (`Pages free` + `Pages speculative`).
- `cached` = reclaimable file cache (`Pages inactive` + `Pages purgeable`).
- `parseVMStatFree` becomes `parseVMStat` returning both; the dashboard shows the cached figure only when non-zero.

## Tests

`parseVMStat` is covered (free vs cached split); full suite + `go vet` green, gofmt clean.

## Related

Refs #542.


___

### **PR Type**
Enhancement


___

### **Description**
- Add `MemCached` field to system-info panel showing reclaimable memory

- Split `parseVMStatFree` into `parseVMStat` returning both free and cached bytes

- Dashboard Memory line now shows `free · cached / total` format when cached > 0

- Update tests and CHANGELOG to reflect the new memory breakdown


___

### Diagram Walkthrough


```mermaid
flowchart LR
  vmstat["vm_stat output"]
  parseVMStat["parseVMStat()"]
  freePages["free + speculative pages"]
  cachedPages["inactive + purgeable pages"]
  infoStruct["Info.MemFree\nInfo.MemCached"]
  dashboard["Dashboard Memory row\n'X free · Y cached / Z'"]

  vmstat -- "parsed by" --> parseVMStat
  parseVMStat -- "returns free" --> freePages
  parseVMStat -- "returns cached" --> cachedPages
  freePages -- "stored in" --> infoStruct
  cachedPages -- "stored in" --> infoStruct
  infoStruct -- "rendered in" --> dashboard
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sysinfo.go</strong><dd><code>Split vm_stat parsing into free and cached memory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tui/internal/sysinfo/sysinfo.go

<ul><li>Added <code>MemCached</code> field to the <code>Info</code> struct<br> <li> Replaced <code>parseVMStatFree</code> with <code>parseVMStat</code> returning <code>(free, cached </code><br><code>uint64)</code><br> <li> <code>free</code> = Pages free + Pages speculative; <code>cached</code> = Pages inactive + Pages <br>purgeable<br> <li> Updated <code>Gather</code> to assign both <code>MemFree</code> and <code>MemCached</code> from the new <br>function</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/553/files#diff-5559ebaa21bae104290784b9c09b76954159a2512249fcf9806e258c069c46f3">+15/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dashboard.go</strong><dd><code>Render cached memory beside free in dashboard Memory row</code>&nbsp; </dd></summary>
<hr>

src/tui/internal/ui/dashboard/dashboard.go

<ul><li>Memory row now conditionally shows cached figure when <code>MemCached > 0</code><br> <li> Format changes from <code>X free / Z</code> to <code>X free · Y cached / Z</code></ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/553/files#diff-c7bc7e7cbd45ac7d4383f156819a36778d321640701281dd9af89cfa73852342">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sysinfo_test.go</strong><dd><code>Update tests for new parseVMStat split return values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/tui/internal/sysinfo/sysinfo_test.go

<ul><li>Renamed <code>TestParseVMStatFree</code> to <code>TestParseVMStat</code><br> <li> Added <code>Pages purgeable</code> line to test fixture<br> <li> Split single assertion into separate checks for <code>free</code> and <code>cached</code> return <br>values</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/553/files#diff-b2a4662d28d2a4f48448f2c3d22e187fb2e178e26326f72fb86ea9e528387cc2">+10/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document cached memory feature in CHANGELOG</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added entry describing the cached memory addition to the <code>sparkdock tui</code> <br>system-info panel</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/553/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

