### PR TITLE
fix(openspec): honor tool list in global skills install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `sjust sf-openspec-install-global` ignoring the tool list once `~/openspec` exists: the script now always runs `openspec init` with the requested tools (additive and idempotent) before refreshing with `openspec update`, so new tools such as `opencode` or `github-copilot` can be added on already-provisioned machines
 - Fixed `sparkdock tui` late output from a cancelled run bleeding into the next run's view (or marking the new run finished): every runner message now carries a run generation stamp and stale messages are dropped
 - Fixed `sparkdock tui` child programs rendering at a stale width after a terminal resize: the child's PTY is now resized (with SIGWINCH) alongside the view
 - Gated the zoxide `cd` alias behind the `CLAUDECODE`/`AI_AGENT` markers so AI coding agents get a literal `cd` (a missing relative path errors instead of frecency-jumping the agent's persistent working directory); interactive shells keep zoxide-backed `cd`, and `zd`/`z`/`zi` stay available everywhere

--- a/sjust/recipes/shared/03-openspec.just
+++ b/sjust/recipes/shared/03-openspec.just
@@ -6,8 +6,8 @@
 sf-openspec-configure $force="":
     {{sparkdock_path}}/sjust/scripts/openspec/configure.sh "${force}"
 
-# Install or update OpenSpec skills and prompts globally in ~/.claude.
-# Pass a comma-separated tool list for first-time init (default: claude).
+# Install or update OpenSpec skills and prompts globally for the given tools.
+# Pass a comma-separated tool list of OpenSpec identifiers (default: claude).
 [group('ai-coding-harness')]
 sf-openspec-install-global $tools="claude":
     {{sparkdock_path}}/sjust/scripts/openspec/install-global-skills.sh "${tools}"

--- a/sjust/scripts/openspec/install-global-skills.sh
+++ b/sjust/scripts/openspec/install-global-skills.sh
@@ -2,14 +2,15 @@
 set -euo pipefail
 
 # Install or update OpenSpec skills and prompt commands in the home directory
-# for Claude Code (and any other already-configured tools).
+# for the requested AI coding tools.
 #
 # OpenSpec installs skills to ~/.claude/skills/openspec-* and prompt commands to
 # ~/.claude/commands/opsx/* relative to a project root. Using ${HOME} as the
 # root makes them global for the user. The home project lives at ~/openspec.
 #
 # Usage: install-global-skills.sh [tools]
-#   tools  — comma-separated tool list for first-time init (default: claude)
+#   tools  — comma-separated tool list (default: claude); OpenSpec identifiers,
+#            e.g. claude, opencode, github-copilot
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -22,15 +23,12 @@ if ! command -v openspec >/dev/null 2>&1; then
     exit 1
 fi
 
-# Already initialized: refresh skills + commands for every configured tool.
-if [[ -d "${HOME}/openspec" ]]; then
-    log_info "Updating global OpenSpec skills and prompts under ${HOME} (all configured tools)"
-    openspec update "${HOME}" --force
-    log_success "Global OpenSpec skills and prompts updated"
-    exit 0
-fi
-
-# First run: scaffold the home project and install the requested tools.
-log_info "Initializing global OpenSpec project at ${HOME}/openspec (tools: ${tools})"
+# Ensure the requested tools are configured. Re-running init is additive and
+# idempotent: it preserves openspec/changes, config.yaml edits, and any tools
+# configured previously (a narrower list never removes tools).
+log_info "Configuring global OpenSpec skills under ${HOME} (tools: ${tools})"
 openspec init "${HOME}" --tools "${tools}" --force
+
+# Refresh instruction files for every configured tool.
+openspec update "${HOME}" --force
 log_success "Global OpenSpec skills and prompts installed for: ${tools}"


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

`sjust sf-openspec-install-global <tools>` accepts a comma-separated tool list, but `sjust/scripts/openspec/install-global-skills.sh` only used it on first-time init. Once `~/openspec` existed, the script ran `openspec update "${HOME}" --force`, which has no `--tools` option and only refreshes tools that are already configured. Requesting a new tool (for example `opencode`) on an already-provisioned machine was a silent no-op.

## Changes

- `install-global-skills.sh`: drop the init/update branch. Always run `openspec init "${HOME}" --tools "${tools}" --force` to ensure the requested tools are configured, then `openspec update "${HOME}" --force` to refresh instruction files for every configured tool.
- `03-openspec.just`: update the recipe doc comment (the tool list is no longer first-init only, and the install is not limited to `~/.claude`).
- `CHANGELOG.md`: add a Fixed entry.

## Safety of re-running `openspec init`

Verified against OpenSpec CLI on an existing project:

- `openspec/changes/` content and `config.yaml` edits are preserved
- adding a new tool installs it alongside the existing ones
- re-running with a narrower list removes nothing, so the `claude` default stays non-destructive on machines that added more tools

Note: the OpenSpec tool identifiers are `claude`, `opencode`, and `github-copilot` (not `copilot`).

Closes #557


___

### **PR Type**
Bug fix


___

### **Description**
- Always run `openspec init` with requested tools before `openspec update`

- Removes silent no-op when adding tools on provisioned machines

- Updates doc comments in script and `just` recipe

- Adds `CHANGELOG.md` entry for the fix


___

### Diagram Walkthrough


```mermaid
flowchart LR
  tools["tools list (e.g. claude,opencode)"] -- "passed to" --> init["openspec init --tools --force"]
  init -- "then" --> update["openspec update --force"]
  update -- "installs/refreshes" --> skills["~/.claude, ~/.opencode, etc skills & prompts"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>install-global-skills.sh</strong><dd><code>Always apply requested tools via init before update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sjust/scripts/openspec/install-global-skills.sh

<ul><li>Removes the branch that skipped <code>--tools</code> when <code>~/openspec</code> already <br>existed<br> <li> Always runs <code>openspec init "${HOME}" --tools "${tools}" --force</code> first<br> <li> Then runs <code>openspec update "${HOME}" --force</code> to refresh all configured <br>tools<br> <li> Updates usage/doc comments to reflect the tool list is honored on <br>every run</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/558/files#diff-14d4cc837f092741b0db6747282996ee57168f131efead5f53a1aee073d99c7c">+10/-12</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>03-openspec.just</strong><dd><code>Update doc comment for global install recipe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sjust/recipes/shared/03-openspec.just

<ul><li>Updates recipe doc comment to clarify tool list is no longer <br>first-init only<br> <li> Clarifies install is not limited to <code>~/.claude</code></ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/558/files#diff-e5ca0921f983bb69159ba023e42738b01346136b91e3f9ed540818214cd668ae">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Add changelog entry for openspec tool list fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Adds a Fixed entry describing the <code>sf-openspec-install-global</code> tool list <br>fix</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/558/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

