### PR TITLE
feat(openspec): add sf-openspec-cleanup-project recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `sjust sf-openspec-cleanup-project` recipe to remove OpenSpec-managed components (skills, commands and prompts) from the current project's `.claude`, `.opencode` and `.github` folders, keeping the `openspec/` folder untouched; pass `dry-run` to only list what would be removed
 - Added an sjust recipe browser to `sparkdock tui` (press `s`): a filterable catalog of the public, argument-free recipes from `just --dump`, grouped and documented, with enter running the selection through the shared runner as `sjust <name>`
 - Added a `?` help overlay to the `sparkdock tui` dashboard with the full key reference for the dashboard, live runs, and finished runs
 - Added outdated package names to the `sparkdock tui` Brew status row (first three, folding the rest into `+N more`), and failing status checks now surface the command's first stderr line instead of a bare "check failed"

--- a/sjust/recipes/shared/03-openspec.just
+++ b/sjust/recipes/shared/03-openspec.just
@@ -11,3 +11,12 @@ sf-openspec-configure $force="":
 [group('ai-coding-harness')]
 sf-openspec-install-global $tools="claude":
     {{sparkdock_path}}/sjust/scripts/openspec/install-global-skills.sh "${tools}"
+
+# Remove OpenSpec-managed components (skills, commands, prompts) from the
+# current local project's .claude, .opencode and .github folders, keeping
+# the openspec/ folder untouched.
+# Pass 'dry-run' to only list what would be removed.
+[no-cd]
+[group('ai-coding-harness')]
+sf-openspec-cleanup-project $mode="":
+    {{sparkdock_path}}/sjust/scripts/openspec/cleanup-project.sh "${mode}"

--- a/sjust/scripts/openspec/cleanup-project.sh
+++ b/sjust/scripts/openspec/cleanup-project.sh
@@ -16,10 +16,30 @@ source "${SCRIPT_DIR}/../../libs/libshell.sh"
 
 mode="${1:-}"
 
+if [[ -n "${mode}" && "${mode}" != "dry-run" ]]; then
+    log_error "Unknown argument '${mode}'. Usage: cleanup-project.sh [dry-run]"
+    exit 1
+fi
+
 root="$(git rev-parse --show-toplevel 2>/dev/null)" || root="${PWD}"
 
-mapfile -d '' -t targets < <(find "${root}/.claude" "${root}/.opencode" "${root}/.github" \
-    -mindepth 2 \( -iname 'openspec*' -o -iname 'opsx*' \) -prune -print0 2>/dev/null || true)
+# OpenSpec only writes into these subdirectories of the tool config folders.
+# Constraining the search here keeps unrelated files that merely share the
+# name prefix (e.g. .github/workflows/openspec-review.yml) out of reach.
+search_dirs=()
+for base in .claude .opencode .github; do
+    for sub in skills commands command prompts; do
+        if [[ -d "${root}/${base}/${sub}" ]]; then
+            search_dirs+=("${root}/${base}/${sub}")
+        fi
+    done
+done
+
+targets=()
+if [[ ${#search_dirs[@]} -gt 0 ]]; then
+    mapfile -d '' -t targets < <(find "${search_dirs[@]}" \
+        -mindepth 1 \( -iname 'openspec*' -o -iname 'opsx*' \) -prune -print0 2>/dev/null || true)
+fi
 
 if [[ ${#targets[@]} -eq 0 ]]; then
     log_info "No OpenSpec components found in .claude, .opencode or .github."
@@ -34,6 +54,16 @@ if [[ "${mode}" == "dry-run" ]]; then
 fi
 
 rm -rf -- "${targets[@]}"
-find "${root}/.claude" "${root}/.opencode" "${root}/.github" \
-    -depth -mindepth 1 -type d -empty -delete 2>/dev/null || true
+
+# Prune only the directories the removal touched, so pre-existing empty
+# folders elsewhere are left alone.
+declare -A pruned
+for target in "${targets[@]}"; do
+    parent="$(dirname "${target}")"
+    if [[ -z "${pruned[${parent}]:-}" ]]; then
+        pruned[${parent}]=1
+        find "${parent}" -depth -type d -empty -delete 2>/dev/null || true
+    fi
+done
+
 log_success "Removed ${#targets[@]} OpenSpec component(s)."

--- a/sjust/scripts/openspec/cleanup-project.sh
+++ b/sjust/scripts/openspec/cleanup-project.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Remove OpenSpec-managed tool components (skills, commands, prompts) from
+# .claude, .opencode and .github in the current repository. The openspec/
+# folder at the repository root is never touched.
+# Covers current layouts (skills/openspec-*, commands/opsx, prompts/opsx-*)
+# and legacy ones (commands/openspec, command/opsx-*, prompts/openspec-*).
+# Usage: cleanup-project.sh [dry-run]
+#   dry-run  — only list what would be removed
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=../../libs/libshell.sh
+source "${SCRIPT_DIR}/../../libs/libshell.sh"
+
+mode="${1:-}"
+
+root="$(git rev-parse --show-toplevel 2>/dev/null)" || root="${PWD}"
+
+mapfile -d '' -t targets < <(find "${root}/.claude" "${root}/.opencode" "${root}/.github" \
+    -mindepth 2 \( -iname 'openspec*' -o -iname 'opsx*' \) -prune -print0 2>/dev/null || true)
+
+if [[ ${#targets[@]} -eq 0 ]]; then
+    log_info "No OpenSpec components found in .claude, .opencode or .github."
+    exit 0
+fi
+
+printf '%s\n' "${targets[@]}"
+
+if [[ "${mode}" == "dry-run" ]]; then
+    log_info "Dry run: nothing removed."
+    exit 0
+fi
+
+rm -rf -- "${targets[@]}"
+find "${root}/.claude" "${root}/.opencode" "${root}/.github" \
+    -depth -mindepth 1 -type d -empty -delete 2>/dev/null || true
+log_success "Removed ${#targets[@]} OpenSpec component(s)."


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @Monska85._

## Summary

- Adds the shared sjust recipe `sf-openspec-cleanup-project`, which removes OpenSpec-managed components (skills, commands and prompts) from the current project's `.claude`, `.opencode` and `.github` folders. The `openspec/` folder at the repository root is never touched.
- The removal patterns were derived from the OpenSpec source code (tool registry and command adapters), so both the current skill-based layout (`skills/openspec-*`, `commands/opsx`, `prompts/opsx-*`) and the legacy pre-1.0 paths (`commands/openspec`, `command/opsx-*`, `prompts/openspec-*`) are covered.
- The recipe runs in the user's working directory via `[no-cd]` and resolves the repository root with `git rev-parse`, so it works from any subdirectory.
- Pass `dry-run` to only list what would be removed without deleting anything.

## Implementation notes

- Logic lives in `sjust/scripts/openspec/cleanup.sh` (bash 5, `set -euo pipefail`, sources `libshell.sh`), keeping the recipe body a one-line orchestration call, as the repository conventions require.
- Shellcheck passes with `-x`; the `# shellcheck source=` directive matches the sibling scripts.
- CHANGELOG entry added under `### Added` in `## [Unreleased]`.

## Testing

- Verified in a fixture repository: dry-run listing, real removal, idempotent second run, empty leftover directories pruned, and `openspec/` plus unrelated files (`.claude/settings.json`, `.github/workflows`) left untouched.
- Also validated against a real repository layout with 54 OpenSpec components across all three folders.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Adds `sf-openspec-cleanup-project` sjust recipe to remove OpenSpec-managed
  components from `.claude`, `.opencode`, `.github` folders

- Supports `dry-run` mode to list removals without deleting

- Implemented in `cleanup-project.sh`, resolving repo root via `git rev-parse`

- Adds CHANGELOG entry documenting the new recipe


___

### Diagram Walkthrough


```mermaid
flowchart LR
  recipe["sf-openspec-cleanup-project recipe"] -- "invokes" --> script["cleanup-project.sh"]
  script -- "resolves" --> root["git repo root"]
  script -- "scans" --> dirs[".claude / .opencode / .github"]
  dirs -- "matches" --> patterns["openspec* / opsx* components"]
  patterns -- "dry-run" --> list["list only"]
  patterns -- "default" --> remove["rm -rf + prune empty dirs"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cleanup-project.sh</strong><dd><code>Add script to clean up OpenSpec-managed project components</code></dd></summary>
<hr>

sjust/scripts/openspec/cleanup-project.sh

<ul><li>New script to find and remove OpenSpec-managed components (skills,<br>   <br>commands, prompts) from <code>.claude</code>, <code>.opencode</code> and <code>.github</code> folders<br> <li> Resolves repository root via <code>git rev-parse --show-toplevel</code>, falling <br>back to <code>PWD</code><br> <li> Supports <code>dry-run</code> argument to only list matches without deleting<br> <li> Removes matched paths and prunes resulting empty directories</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/560/files#diff-9ccca0404c46a88ab0a225d3f3a1e4920bb60e0cf88cfd9bfb7bec4c42e6a713">+39/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>03-openspec.just</strong><dd><code>Register sf-openspec-cleanup-project sjust recipe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sjust/recipes/shared/03-openspec.just

<ul><li>Adds new <code>sf-openspec-cleanup-project</code> recipe with <code>[no-cd]</code> and<br>   <br><code>ai-coding-harness</code> group<br> <li> Delegates to <code>cleanup-project.sh</code>, forwarding the <code>mode</code> argument</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/560/files#diff-e5ca0921f983bb69159ba023e42738b01346136b91e3f9ed540818214cd668ae">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document new cleanup-project recipe in changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Documents the new <code>sjust sf-openspec-cleanup-project</code> recipe under <br><code>Unreleased/Added</code></ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/560/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

