### PR TITLE
fix(agents-sync): stop warning on empty upstream agents/system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `sparkdock-agents-sync` printing a spurious `WARN No 'agents/system/' directory found in upstream repo.` on every run: upstream now advertises no system agents (`catalog.json` `"agents": {}`, the-architect removed), so an absent or empty `agents/system/` is a valid state and no longer warns
 - Fixed `sjust sf-openspec-install-global` ignoring the tool list once `~/openspec` exists: the script now always runs `openspec init` with the requested tools (additive and idempotent) before refreshing with `openspec update`, so new tools such as `opencode` or `github-copilot` can be added on already-provisioned machines
 - Fixed `sparkdock tui` late output from a cancelled run bleeding into the next run's view (or marking the new run finished): every runner message now carries a run generation stamp and stale messages are dropped
 - Fixed `sparkdock tui` child programs rendering at a stale width after a terminal resize: the child's PTY is now resized (with SIGWINCH) alongside the view

--- a/bin/sparkdock-agents-sync
+++ b/bin/sparkdock-agents-sync
@@ -383,12 +383,12 @@ sync_agent_profile() {
 # Sync all agents from the upstream cache.
 sync_agents() {
     local system_dir="${CACHE_DIR}/${SYSTEM_AGENTS_SUBDIR}"
+    # An absent or empty agents/system/ is a valid state: upstream currently
+    # advertises no system agents (catalog "agents": {}). Return silently.
     if [[ ! -d "${system_dir}" ]]; then
-        log_warn "No '${SYSTEM_AGENTS_SUBDIR}/' directory found in upstream repo."
         return
     fi
 
-    local found=false
     for agent_dir in "${system_dir}"/*/; do
         [[ -d "${agent_dir}" ]] || continue
         local agent_name
@@ -407,14 +407,9 @@ sync_agents() {
                 continue
             fi
 
-            found=true
             sync_agent_profile "${agent_name}" "${tool_name}"
         done
     done
-
-    if [[ "${found}" = false ]]; then
-        log_warn "No valid agents found in '${SYSTEM_AGENTS_SUBDIR}/'."
-    fi
 }
 
 # --- Orphan cleanup ---


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

`bin/sparkdock-agents-sync` printed `WARN No 'agents/system/' directory found in upstream repo.` on every `sjust sf-harness-sync` run.

The warning assumed `agents/system/` always exists upstream. Upstream now advertises zero system agents (`config/catalog.json` has `"agents": {}`, and `the-architect` was removed), so the empty directory is dropped from the clone. An absent or empty `agents/system/` is a valid state, not an error.

## Changes

- `sync_agents()` returns silently when `agents/system/` is absent, instead of warning.
- Removed the "No valid agents found" warning for the empty case, along with the now-dead `found` tracking variable.
- Added a `CHANGELOG.md` entry under Fixed.

The domain-specific `agents/drupal/*.agent.md` files are not in the catalog and are not intended for global installation, so they remain out of scope for this sync. The `sparkdock-agents-status` script already handled the empty case gracefully and needed no change.

## Verification

- `sjust sf-harness-sync` now runs without the warning; skills still report 17 unchanged.
- `shellcheck` passes (only pre-existing info/style findings, none in the changed lines).

Closes #561


___

### **PR Type**
Bug fix


___

### **Description**
- Stop spurious `WARN` when upstream `agents/system/` is absent/empty

- Remove now-dead `found` tracking variable and related warning

- Add `CHANGELOG.md` entry under Fixed


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["sync_agents()"] -- "absent/empty agents/system/" --> B["return silently"]
  A -- "agents found" --> C["sync_agent_profile()"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sparkdock-agents-sync</strong><dd><code>Silence spurious warnings for empty agents/system directory</code></dd></summary>
<hr>

bin/sparkdock-agents-sync

<ul><li>Removed <code>log_warn</code> call when <code>agents/system/</code> directory is missing, now <br>returns silently<br> <li> Removed the <code>found</code> tracking variable and its associated "No valid <br>agents found" warning<br> <li> Added a comment explaining that absent/empty <code>agents/system/</code> is a valid <br>state</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/562/files#diff-a4937e767294b298c6848cc2d41a4c546ec326540e29b9720d75bc2fa99457ca">+2/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document fix for spurious agents-sync warning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

- Added changelog entry under Fixed describing the sync warning fix


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/562/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

