### PR TITLE
fix(ansible): validate the sudo password before provisioning starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a mistyped sudo password only surfacing minutes into provisioning with a cryptic ansible-core error: the become password collected by `--ask-become-pass` is now probed against sudo at the start of the play, aborting in seconds with a clear message; skipped in CI/non-interactive runs
 - Fixed `sparkdock-agents-sync` printing a spurious `WARN No 'agents/system/' directory found in upstream repo.` on every run: upstream now advertises no system agents (`catalog.json` `"agents": {}`, the-architect removed), so an absent or empty `agents/system/` is a valid state and no longer warns
 - Fixed `sjust sf-openspec-install-global` ignoring the tool list once `~/openspec` exists: the script now always runs `openspec init` with the requested tools (additive and idempotent) before refreshing with `openspec update`, so new tools such as `opencode` or `github-copilot` can be added on already-provisioned machines
 - Fixed `sparkdock tui` late output from a cancelled run bleeding into the next run's view (or marking the new run finished): every runner message now carries a run generation stamp and stale messages are dropped

--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -22,6 +22,25 @@
       set_fact:
         is_non_interactive: "{{ ansible_facts['env'].CI is defined or ansible_facts['env'].GITHUB_ACTIONS is defined or ansible_facts['env'].RUNNER_OS is defined or ansible_facts['env'].HOME == '/var/root' or ansible_facts['env'].ANSIBLE_SUDO_PASSWORD is defined }}"
 
+    # The become password collected by --ask-become-pass is not verified at
+    # prompt time, so a typo would otherwise surface only at the first become
+    # task, deep into the run. Probe sudo once up front and abort immediately.
+    - name: Validate sudo password before provisioning
+      tags: always
+      when: not is_non_interactive
+      block:
+        - name: Check the become password against sudo
+          command: /usr/bin/true
+          become: yes
+          changed_when: false
+      rescue:
+        - name: Abort on invalid sudo password
+          fail:
+            msg: >-
+              Sudo password check failed: the password entered at the
+              'BECOME password:' prompt was rejected. Re-run sparkdock and
+              enter your macOS login password.
+
     - name: Load all packages
       include_vars:
         file: "{{ dev_env_dir }}/config/packages/all-packages.yml"


### PR DESCRIPTION
### **User description**
## What

Validates the sudo password right at the start of the Ansible provisioning run, instead of letting a typo surface minutes later.

## Why

The password collected by the `BECOME password:` prompt was never checked when you typed it. If you mistyped it, provisioning ran for several minutes and then failed at the first privileged task with a cryptic ansible-core error ("Duplicate become password prompt encountered").

## How

A tiny probe task at the top of the play runs `/usr/bin/true` with `become: yes`, so sudo verifies the stored password within seconds of the prompt. If the password is wrong, the run aborts immediately with a clear message: re-run sparkdock and enter your macOS login password.

Notes:

- The password handling is unchanged: it stays in Ansible memory, never in the environment, argv, files, or logs.
- The probe is skipped in CI and other non-interactive runs, which use passwordless `--become`.
- Tested manually with a wrong password: the run aborts in seconds with the friendly message (`rescued=1`).


___

### **PR Type**
Bug fix


___

### **Description**
- Validates sudo password early to avoid late failures

- Adds probe task using `/usr/bin/true` with `become: yes`

- Aborts with clear message on invalid password via rescue block

- Skipped in CI and non-interactive runs

- Updates `CHANGELOG.md` with fix description


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Ansible play starts"] --> B["Check non-interactive env"]
  B -- "interactive" --> C["Probe sudo password (/usr/bin/true, become: yes)"]
  C -- "success" --> D["Continue provisioning"]
  C -- "failure" --> E["Abort with clear error message"]
  B -- "non-interactive" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base.yml</strong><dd><code>Add early sudo password validation probe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ansible/macos/macos/base.yml

<ul><li>Adds a new task "Validate sudo password before provisioning" that runs <br>early in the play<br> <li> Uses a <code>block</code>/<code>rescue</code> structure to probe sudo via <code>/usr/bin/true</code> with <br><code>become: yes</code><br> <li> Skips the probe when <code>is_non_interactive</code> is true<br> <li> On failure, fails with a clear message asking the user to re-enter <br>their macOS login password</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/563/files#diff-35e06808caf91480daa0d30bc6b6a1e4c425376bb5d3196d021dca2357bdd621">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document sudo password validation fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Documents the fix for mistyped sudo passwords causing late <br>provisioning failures<br> <li> Explains the new probe behavior and CI/non-interactive skip</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/563/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

