### PR TITLE
fix(packages): upgrade google-cloud-sdk on every provision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Moved `google-cloud-sdk` from `cask_packages` to `cask_latest_packages`, so an existing Google Cloud SDK is upgraded on every provisioning pass instead of staying pinned at the version installed on first provision
 - Changed `sparkdock tui` status checks to run in parallel and stream into the dashboard row by row, each under a 60-second timeout so a hung command can never pin a row on the loading ellipsis; returning to the dashboard keeps the previous rows visible while the new round refreshes in the background
 - Changed `sparkdock-tui update` and `--no-tui` to exec the `sparkdock` bash entrypoint (self-update plus provisioning) instead of printing a stub; a bare non-TTY invocation now refuses with guidance rather than provisioning implicitly
 - Changed `sparkdock tui` run cancellation to signal the child's whole process group (nested processes included) and escalate to SIGKILL after a five-second grace period if SIGINT is ignored

--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -259,21 +259,21 @@
       shell: source {{ homebrew_prefix }}/share/google-cloud-sdk/path.zsh.inc && gcloud components install gke-gcloud-auth-plugin --quiet
       args:
         executable: /bin/zsh
-      when: "'google-cloud-sdk' in all_cask_packages"
+      when: "'google-cloud-sdk' in all_cask_latest_packages"
       become: false
 
     - name: Disable gcloud survey prompts
       shell: source {{ homebrew_prefix }}/share/google-cloud-sdk/path.zsh.inc && gcloud config set survey/disable_prompts true
       args:
         executable: /bin/zsh
-      when: "'google-cloud-sdk' in all_cask_packages"
+      when: "'google-cloud-sdk' in all_cask_latest_packages"
       become: false
 
     - name: Disable gcloud usage reporting
       shell: source {{ homebrew_prefix }}/share/google-cloud-sdk/path.zsh.inc && gcloud config set core/disable_usage_reporting true
       args:
         executable: /bin/zsh
-      when: "'google-cloud-sdk' in all_cask_packages"
+      when: "'google-cloud-sdk' in all_cask_latest_packages"
       become: false
 
     - name: Check if npm command is available

--- a/config/packages/all-packages.yml
+++ b/config/packages/all-packages.yml
@@ -5,7 +5,6 @@ taps:
 
 # Cloud Tools, Applications, and Fonts
 cask_packages:
-  - google-cloud-sdk
   - applite
   - font-caskaydia-mono-nerd-font
   - font-droid-sans-mono-nerd-font
@@ -40,6 +39,7 @@ cask_install_once_packages:
 cask_latest_packages:
   - claude-code@latest
   - copilot-cli
+  - google-cloud-sdk
 
 homebrew_packages:
   # Modern bash (5.x). macOS still ships /bin/bash 3.2 because bash 4+ is GPLv3.


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

Closes #568

## Problem

`google-cloud-sdk` was listed in `cask_packages` in `config/packages/all-packages.yml`. That list feeds the "Install cask packages" task in `ansible/macos/macos/base.yml`, which uses `state: present`, meaning install-if-missing. Only `cask_latest_packages` goes through the "Upgrade cask packages to latest" task with `state: upgraded`.

The result: once the cask was installed, `gcloud` stayed at that version forever. Observed on a developer machine: `566.0.0` installed against `577.0.0` in the rapid channel.

## Change

- Moved `google-cloud-sdk` from `cask_packages` to `cask_latest_packages`.
- Updated the three `gcloud` post-install tasks (auth plugin, survey prompts, usage reporting) to gate on `all_cask_latest_packages` instead of `all_cask_packages`, since the package no longer appears in the old list.

## Notes on the implementation

**No fresh-machine regression.** In `community.general.homebrew_cask`, `_upgrade_current_cask` switches its command to `install` when the cask is not present, and returns unchanged when the cask is present and not outdated. So `cask_latest_packages` correctly serves as both an install list and an upgrade list. This is already how `claude-code@latest` and `copilot-cli` reach fresh machines.

**Components survive.** Upgrading a cask is an uninstall plus reinstall, which discards anything added by `gcloud components install`, including `gke-gcloud-auth-plugin`. The auth plugin task at `base.yml:258` runs after the upgrade loop, so it reinstalls the plugin on the same pass and the install self-heals.

**Assertion still covers it.** The "Assert cask packages installed" check at `base.yml:246` iterates `all_cask_packages + all_cask_latest_packages`, so `google-cloud-sdk` remains verified after the move.

## Verification

- Confirmed `state: upgraded` install-when-absent behavior by reading the installed `community.general.homebrew_cask` module source rather than assuming it.
- `config/packages/all-packages.yml` and `ansible/macos/macos/base.yml` both parse cleanly, and the two cask lists resolve as intended.
- No other consumer references `cask_packages` or `cask_latest_packages` outside the Ansible play, so nothing downstream needed updating.

The Linux counterpart is sparkfabrik/archlinux-ansible-provisioner#240.


___

### **PR Type**
Bug fix


___

### **Description**
- Moved `google-cloud-sdk` from `cask_packages` to `cask_latest_packages` to ensure it is upgraded on every provisioning pass

- Updated three `gcloud` post-install tasks (auth plugin, survey prompts, usage reporting) to gate on `all_cask_latest_packages` instead of `all_cask_packages`

- Added changelog entry documenting the fix


___

### Diagram Walkthrough


```mermaid
  flowchart LR
    A["google-cloud-sdk in cask_packages"] -- "moved to" --> B["cask_latest_packages"]
    B -- "triggers upgrade on every run" --> C["gcloud stays up to date"]
    B -- "gate condition updated" --> D["Post-install tasks use all_cask_latest_packages"]
    D --> E["Install gke-gcloud-auth-plugin"]
    D --> F["Disable survey prompts"]
    D --> G["Disable usage reporting"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>all-packages.yml</strong><dd><code>Move google-cloud-sdk to cask_latest_packages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/packages/all-packages.yml

<ul><li>Removed <code>google-cloud-sdk</code> from <code>cask_packages</code> list<br> <li> Added <code>google-cloud-sdk</code> to <code>cask_latest_packages</code> list so it is upgraded <br>on every provisioning run</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/569/files#diff-3ae984d019cd232f8832790630553e4e2af38f6fc97846eedf247fc19cc5b0dd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base.yml</strong><dd><code>Update gcloud post-install task conditions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ansible/macos/macos/base.yml

<ul><li>Updated <code>when</code> condition for "Install gke-gcloud-auth-plugin component" <br>task from <code>all_cask_packages</code> to <code>all_cask_latest_packages</code><br> <li> Updated <code>when</code> condition for "Disable gcloud survey prompts" task from <br><code>all_cask_packages</code> to <code>all_cask_latest_packages</code><br> <li> Updated <code>when</code> condition for "Disable gcloud usage reporting" task from <br><code>all_cask_packages</code> to <code>all_cask_latest_packages</code></ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/569/files#diff-35e06808caf91480daa0d30bc6b6a1e4c425376bb5d3196d021dca2357bdd621">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document gcloud upgrade fix in changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added changelog entry under "Changed" section documenting the move of <br><code>google-cloud-sdk</code> to <code>cask_latest_packages</code></ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/569/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



---

> Assisted-by: pr-agent/z-ai/glm-5.2