### PR TITLE
Add macos-option-as-alt configuration

### DIFF
--- a/config/shell/config/ghostty/config
+++ b/config/shell/config/ghostty/config
@@ -21,6 +21,7 @@ mouse-scroll-multiplier = 2
 # MacOS Specific
 macos-non-native-fullscreen = true
 font-thicken = false
+macos-option-as-alt = left
 
 # Keybindings
 keybind = ctrl+shift+n=new_window


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Configure the left Option key as Alt.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  macOS["macOS keyboard settings"]
  Ghostty["Ghostty Option-as-Alt behavior"]
  macOS -- "maps left Option key" --> Ghostty
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config</strong><dd><code>Configure left Option key as Alt</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/shell/config/ghostty/config

<ul><li>Add <code>macos-option-as-alt = left</code> to Ghostty's macOS-specific settings.<br> <li> Configure only the left Option key to act as Alt.</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/581/files#diff-b052dd756b9a2f8869c061c12ee4a364872451c289ca5b01947ba6170b6c30e8">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



---

> Assisted-by: pr-agent/gpt-5.6-terra