### PR TITLE
fix(shell): bind option+backspace to word delete in ghostty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed Option+Backspace deleting a single character instead of the previous word in the Ghostty base config, by binding `alt+backspace` to `ESC DEL` rather than setting `macos-option-as-alt`, which would stop Option composing `@`, `#`, `[`, `]`, `{` and `}` on the Italian Mac layout
 - Fixed the AGENTS.md privilege-escalation section, which described the become password as being collected via `--ask-become-pass`. The play uses `vars_prompt` instead, precisely because `--ask-become-pass` never defines the `ansible_become_pass` template variable the cask tasks depend on. The TUI section carried the same error, contradicting the test that asserts the flag is absent
 - Fixed the OpenCode deploy message reporting 175 permission rules when the config holds 172
 - Fixed caveman setup failing with `Cannot find module .../caveman/bin/install.js` after upstream moved the installer from `bin/` to `cli/`; the setup and uninstall paths now point at `cli/install.js`

--- a/config/shell/config/ghostty/config
+++ b/config/shell/config/ghostty/config
@@ -23,6 +23,12 @@ macos-non-native-fullscreen = true
 font-thicken = false
 
 # Keybindings
+# Option+Backspace sends ESC DEL so shells and TUIs delete the previous word.
+# Bound as a single chord on purpose: macos-option-as-alt would fix this too, but
+# it stops Option composing @ # [ ] { } on the Italian Mac layout.
+# This file is shared with Linux (ajust), where Alt+Backspace already sends the
+# same bytes, so the bind is a no-op there apart from pinning the legacy encoding.
+keybind = alt+backspace=text:\x1b\x7f
 keybind = ctrl+shift+n=new_window
 keybind = cmd+c=copy_to_clipboard
 keybind = cmd+v=paste_from_clipboard


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

Supersedes #581, which fixed the same problem with `macos-option-as-alt = left`.

## What

Bind Option+Backspace to `ESC DEL` in the Ghostty base config so shells and TUIs delete the previous word:

```conf
keybind = alt+backspace=text:\x1b\x7f
```

## Why

Option+Backspace deleted a single character. zsh binds `ESC DEL` to `backward-kill-word`, but Ghostty does not emit that sequence unless it is told to treat Option as Alt, and the base config configured neither.

This surfaced through herdr (herdrdev/herdr#2030, a duplicate of herdrdev/herdr#155). The herdr side was fixed in 0.5.11 and shipped in 0.7.5, so on current versions the remaining gap is entirely in terminal configuration.

## Why not `macos-option-as-alt`

That setting is the documented workaround and is what #581 used, but it makes an Option key send Alt for every chord, so that key stops composing characters. On the Italian Mac layout the characters used constantly while coding sit behind Option on right-side keys:

- **`@`** is Option+ò
- **`#`** is Option+à
- **`[`** and **`]`** are Option+è and Option+plus
- **`{`** and **`}`** add Shift to the same two keys

Those are typed with the left Option and the right hand, the usual opposite-hand modifier reach, which leaves three bad options:

- **`= left`** breaks exactly that reach, moving brackets and `@` to a cramped same-hand press.
- **`= right`** keeps the brackets but makes Option+Backspace the cramped press instead.
- **`= true`** breaks both Option keys.

Binding the one chord avoids the choice. Ghostty resolves the keybind ahead of Option composition, so word delete works on both Option keys and every composed character keeps working.

## Trade-offs

- **Legacy encoding only.** `text:` writes literal bytes, so an application that negotiates the Kitty keyboard protocol receives the legacy `ESC DEL` form rather than a CSI-u sequence. Applications that speak the modern protocol keep a legacy fallback, so this degrades rather than breaks.
- **One chord only.** `alt+f`, `alt+b` and `alt+d` stay unbound. Anyone who wants the full Alt set can set `macos-option-as-alt` in their own overrides file, which still takes precedence.
- **Scoped to Ghostty.** Other applications keep their own Option+Backspace behavior.

## Effect on Linux

`shell-ghostty-setup` lives in `sjust/recipes/shared/` and is reused by `ajust` on Linux, so this config applies there too. The effect differs by platform:

- **macOS** gains the behavior. Option is a compose key and Ghostty emits nothing useful for the chord without help.
- **Linux** is unchanged for legacy applications. Alt is a real Alt key, Ghostty already encodes Alt+Backspace as `ESC DEL`, and the bind writes the same bytes.
- **Kitty-protocol applications on Linux** get a small downgrade. They would otherwise receive the CSI-u form and now always receive legacy `ESC DEL`, since `text:` skips protocol negotiation. They keep a legacy fallback, so this degrades rather than breaks.

Splitting the bind into a macOS-only include was considered and rejected. Ghostty has no OS conditional in its config, so it would require a platform-specific `config-file` line emitted by `sparkdock_setup_ghostty_config`, and that function returns early when the two-file setup already exists. Existing machines would never pick up the new include, so the split would only reach fresh installs. A one-chord legacy pin on Linux is the cheaper trade.

## Testing

Verified on Ghostty 1.3.1 with herdr 0.8.0 (client and server, protocol 19):

- Option+Backspace deletes the previous word in zsh, with both the left and the right Option key.
- `@`, `#`, `[`, `]`, `{` and `}` still compose normally on both Option keys.
- Word delete works inside a herdr pane.

## Note on reach

The base config only applies to machines using the two-file setup created by `sparkdock_setup_ghostty_config` in `sjust/libs/libshell.sh`. Where `~/.config/ghostty/config` is hand-managed, that function detects the existing file and prints migration instructions without writing, so the base config never loads. Existing behavior, out of scope here.

Closes #582
