### PR TITLE
fix(shell): return real ls to scripts and match options only

### DIFF
--- a/config/shell/aliases.zsh
+++ b/config/shell/aliases.zsh
@@ -84,20 +84,43 @@ if command_exists eza; then
   unalias ls 2>/dev/null || true
 
   function ls() {
-    local filtered_args=("${@[@]//-ltr/}")
-    filtered_args=("${filtered_args[@]//-lt/}")
+    # Only dress up interactive use. Scripts, pipelines, editors and coding
+    # agents get the real ls, so `ls -d some/path` returns a path rather than a
+    # formatted table with a header row.
+    if [[ ! -o interactive || ! -t 1 ]]; then
+      command ls "$@"
+      return
+    fi
 
-    case "$*" in
-      *ltr*)
-        eza -lag --icons=auto --sort=modified ${filtered_args[@]}
-        ;;
-      *lt*)
-        eza -lag --icons=auto --sort=modified --reverse ${filtered_args[@]}
-        ;;
-      *)
-        eza -lhg --group-directories-first --icons=auto "$@"
-        ;;
-    esac
+    # Inspect options only. Matching against "$*" tested the whole argument
+    # string, so any path containing "lt" or "ltr" silently switched to
+    # sort-by-modified and revealed hidden files: ls faults/, ls halt.txt,
+    # ls results/ all took the wrong branch.
+    local -a rest
+    local sort_modified=0 reverse=1 arg stripped
+    for arg in "$@"; do
+      case $arg in
+        -[!-]*)
+          stripped=$arg
+          case $arg in
+            *ltr*) sort_modified=1; reverse=0; stripped=${arg//[ltr]/} ;;
+            *lt*)  sort_modified=1; reverse=1; stripped=${arg//[lt]/} ;;
+          esac
+          [[ $stripped != - ]] && rest+=("$stripped")
+          ;;
+        *) rest+=("$arg") ;;
+      esac
+    done
+
+    if (( sort_modified )); then
+      if (( reverse )); then
+        eza -lag --icons=auto --sort=modified --reverse "${rest[@]}"
+      else
+        eza -lag --icons=auto --sort=modified "${rest[@]}"
+      fi
+    else
+      eza -lhg --group-directories-first --icons=auto "$@"
+    fi
   }
   alias lsa='ls -a'
   alias lt='eza --tree --level=2 --long --icons --git'


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

Closes #586

The `ls` function in `config/shell/aliases.zsh` replaced `ls` with `eza` for every caller and chose its eza flags by matching the whole argument string. This fixes both, and two smaller problems in the same function.

## Non-interactive callers get the real ls

```zsh
if [[ ! -o interactive || ! -t 1 ]]; then
  command ls "$@"
  return
fi
```

The function always emitted a long-format table with a header row, so `ls -d some/path` returned a table rather than a path. Anything parsing the output broke: shell scripts, editors, and coding agents that run commands through a login shell.

Because `sparkdock.zshrc` is sourced after a user's own dotfiles, this definition also won over any local override, so it could not be worked around downstream.

## Sort selection inspects options, not filenames

The `case` statement tested `"$*"`, which contains filenames as well as options, so any path containing `lt` or `ltr` took a branch that sorts by modification time and passes `-a`. Selection now walks the arguments and only considers those starting with a single hyphen.

## Two smaller problems

- **The eza arguments were unquoted**, so any path containing a space was split into separate arguments.
- **Option filtering used substring substitution**, which rewrote a filename containing `-ltr` and did not cleanly strip a combined option such as `-alt`.

## Verification

Interactive behaviour is unchanged. Checked on a pty, since the guard means a piped test exercises the fallback rather than eza:

| Command | Before | After |
| --- | --- | --- |
| `ls faults/` | sorted by mtime, `.hidden` shown, no header | name order, `.hidden` hidden, header present |
| `ls -lt dir` | sorted by mtime with `-a` | unchanged |
| `ls -d path` (piped) | formatted table | bare path |

`faults` is an ordinary directory name; it triggered the bug only because it contains the letters `lt`.


___

### **PR Type**
Bug fix


___

### **Description**
- Preserve native `ls` for scripts and pipes

- Restrict sort detection to option arguments

- Preserve spaced paths and combined options


___

### Diagram Walkthrough


```mermaid
flowchart LR
  input["ls invocation"]
  guard["Check interactive shell and terminal stdout"]
  native["Run native ls"]
  eza["Run interactive eza wrapper"]
  options["Parse single-dash sort options"]
  input -- "not interactive or piped" --> guard
  guard -- "fallback" --> native
  guard -- "interactive terminal" --> options
  options -- "render output" --> eza
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>aliases.zsh</strong><dd><code>Harden interactive `ls` wrapper argument handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/shell/aliases.zsh

<ul><li>Fall back to <code>command ls "$@"</code> for non-interactive shells or <br>non-terminal stdout.<br> <li> Parse only single-dash options when detecting <code>-lt</code> and <code>-ltr</code> sorting.<br> <li> Remove sort flags without rewriting filenames and preserve remaining <br>arguments.<br> <li> Quote forwarded <code>eza</code> arguments to support paths containing spaces.</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/587/files#diff-fe1e4df088c825fe14cb629660151d77d5debec9455646f03c762f2aefb8f03a">+36/-13</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



---

> Assisted-by: pr-agent/gpt-5.6-terra