### PR TITLE
fix(menubar): install the latest claude-usage on every run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Provisioning now installs the latest `claude-usage` release on every run instead of pinning `v0.6.0`: the version pin and the `creates:` guard are gone, so an already-installed copy is upgraded (currently to `v0.7.0`, which reads limits from the OAuth endpoint and enriches `--status`). The upstream installer short-circuits when the recorded version already matches, so repeated runs stay cheap and the task only reports `changed` when binaries are actually installed
 - Folded Sparkdock Manager upgrade actions into the System status rows and scoped refresh controls to their respective sections
 - Moved the Sparkdock Manager Claude usage refresh control beside its section title and made it more visible
 - Changed the AI coding harness upstream repository URL from `sparkfabrik/sf-awesome-copilot` to `sparkfabrik/sf-agents-harness` following the upstream rename

--- a/ansible/macos/macos/base.yml
+++ b/ansible/macos/macos/base.yml
@@ -735,17 +735,17 @@
     - name: Install Sparkdock Menu Bar App
       tags: menubar
       block:
-        - name: Install Claude usage provider without standalone reader
+        - name: Install or upgrade Claude usage provider without standalone reader
           ansible.builtin.command:
             argv:
               - /usr/bin/env
               - bash
               - "{{ dev_env_dir }}/sjust/scripts/claude-usage.sh"
               - install
-              - v0.6.0
-            creates: "{{ ansible_facts['env']['HOME'] }}/.local/bin/claude-usage"
           environment:
             CLAUDE_USAGE_READER: "0"
+          register: claude_usage_install
+          changed_when: "'installed binaries (' in claude_usage_install.stdout"
           become: false
 
         - name: Build menu bar app


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Problem

The provisioning task that installs [claude-usage](https://github.com/sparkfabrik/claude-usage) was pinned to `v0.6.0` and guarded with `creates:` on the installed binary.

That combination means the tool is never upgraded. Once `~/.local/bin/claude-usage` exists the task is skipped entirely, and even without the guard the pin would keep every machine on `v0.6.0`. Upstream released `v0.7.0` on 2026-08-25 (limits read from the OAuth endpoint, enriched `--status`), and no provisioned machine would have picked it up.

## Change

- Drop the `v0.6.0` argument so `sjust/scripts/claude-usage.sh install` resolves the latest release.
- Drop the `creates:` guard so the task runs on every provisioning pass.
- Register the command and set `changed_when` on the installer's `installed binaries (` marker, so the task reports `changed` only when binaries are actually written.

## Why running every pass is cheap

The upstream `install.sh` is idempotent. It writes the installed tag to `~/.local/share/claude-usage/.version` and skips the download when that tag matches the target and the expected artifacts are present. A no-op pass costs the release-metadata lookup and the installer download, nothing more.

## Verification

- `ansible/macos/macos/base.yml` parses as valid YAML.
- The wrapper's latest path resolves: `releases/latest/download/install.sh` downloads and verifies clean against the release `checksums.txt` (`install.sh: OK`).
- The menu bar app only calls `claude-usage --status` and `--status --force-poll`, both unchanged in `v0.7.0`, and the `v0.7.0` additions to the status payload are additive.


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Provisioning tracks the latest `claude-usage` release

- Existing installations upgrade on subsequent runs

- Change reporting reflects actual binary installations

- Changelog documents idempotent upgrade behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  provisioning["macOS provisioning"]
  installer["Claude usage install wrapper"]
  release["Latest upstream release"]
  status["Accurate Ansible change status"]
  provisioning -- "runs every pass" --> installer
  installer -- "resolves and installs" --> release
  installer -- "reports installation output" --> status
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document automatic Claude usage provider upgrades</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Documents automatic latest-release provisioning<br> <li> Explains idempotent repeated runs<br> <li> Notes current <code>v0.7.0</code> capabilities</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/594/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base.yml</strong><dd><code>Track latest Claude usage provider during provisioning</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ansible/macos/macos/base.yml

<ul><li>Removes the fixed <code>v0.6.0</code> argument<br> <li> Runs installation despite an existing binary<br> <li> Registers installer output for change detection<br> <li> Marks changes only when binaries install</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/594/files#diff-35e06808caf91480daa0d30bc6b6a1e4c425376bb5d3196d021dca2357bdd621">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



---

> Assisted-by: pr-agent/gpt-5.6-sol