### PR TITLE
fix(menubar): resolve the latest claude-usage tag without the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed provisioning failing at the `claude-usage` install step with `curl: (56) The requested URL returned error: 403`: resolving the latest release was delegated to the upstream installer, which asks `api.github.com`, and that endpoint is rate limited per IP, so CI runners on shared addresses were refused and the whole run aborted. The wrapper now resolves the tag from the `github.com` release redirect and pins it, so no API call is made; if the redirect cannot be read it falls back to the previous behaviour
 - Fixed Sparkdock Manager process checks leaving timed-out commands running, stale Claude usage refreshes overwriting newer results, incorrect single-update grammar, and menubar provisioning under-reporting Claude provider installations
 - Fixed the caveman setup script aborting provisioning with `Cannot find module .../install.js` whenever upstream relocates its native installer, which it has now done in both directions (`bin/` to `cli/`, then back to `bin/`). The setup and uninstall paths resolve the entrypoint at runtime, probing `bin/install.js` then `cli/install.js`, so either upstream layout works, and report a clear error when neither exists instead of failing with a Node stack trace
 - Fixed overlapping Claude Code usage rows in Sparkdock Manager and adjusted menu heading sizes for clearer hierarchy

--- a/sjust/scripts/claude-usage.sh
+++ b/sjust/scripts/claude-usage.sh
@@ -85,6 +85,17 @@ _fetch_installer() {
     echo "raw"
 }
 
+# Resolve the latest release tag from the github.com redirect rather than the
+# API. Unauthenticated api.github.com calls are rate limited per IP, and CI
+# runners share addresses, so the installer's own lookup answers 403 there and
+# aborts the whole run. Echoes the tag; non-zero when it cannot be resolved.
+_resolve_latest_tag() {
+    local url
+    url="$(curl -fsSLI -o /dev/null -w '%{url_effective}' "${RELEASES_URL}/latest" 2>/dev/null)" || return 1
+    [[ "${url}" =~ /tag/(v[0-9]+\.[0-9]+\.[0-9]+)$ ]] || return 1
+    printf '%s' "${BASH_REMATCH[1]}"
+}
+
 cmd_install() {
     local version="${1:-}" ref pin_tag tmp src
     if [[ -n "${version}" ]]; then
@@ -92,8 +103,13 @@ cmd_install() {
         ref="${version}"
         pin_tag="${version}"
     else
-        ref="latest"
-        pin_tag=""
+        # Pin the resolved tag so the installer never has to ask the API, and
+        # take the installer from that same release so the script and the
+        # binaries it downloads always match. When the redirect cannot be read,
+        # fall back to "latest" and let the installer do its own lookup, which
+        # still works from an unthrottled address.
+        pin_tag="$(_resolve_latest_tag)" || pin_tag=""
+        ref="${pin_tag:-latest}"
     fi
 
     tmp="$(mktemp -d)"


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

Fixes the `master` breakage introduced by #594.

## What broke

#594 stopped pinning `claude-usage` so provisioning would track the latest release. That handed the version lookup to the upstream installer, which resolves it through `api.github.com`. Unauthenticated calls to the API are rate limited per IP, and GitHub-hosted runners share addresses, so the request was refused and the whole run aborted:

```
curl: (56) The requested URL returned error: 403
ERROR: Failed to fetch latest release. Set CLAUDE_USAGE_VERSION manually.
```

Seen in [run 32905124431](https://github.com/sparkfabrik/sparkdock/actions/runs/32905124431/job/97987400613), on `macos-26`. The pinned call in the previous code never hit this path, because a pinned tag means the installer has nothing to look up.

## The fix

`sjust/scripts/claude-usage.sh` resolves the tag itself, from the `github.com` release redirect rather than the API:

```
https://github.com/sparkfabrik/claude-usage/releases/latest
  -> https://github.com/sparkfabrik/claude-usage/releases/tag/v0.7.0
```

That host was already reachable in the same failing job, which downloaded and checksum-verified `install.sh` seconds before the 403. The resolved tag is passed as `CLAUDE_USAGE_VERSION`, so the installer skips its own lookup entirely, and it is also used as the ref for fetching `install.sh`, so the installer and the binaries it downloads always come from one release.

If the redirect cannot be read, the tag stays empty and the previous behaviour applies, which still works from an unthrottled address. Tracking the latest release is unchanged.

## Verification

- The redirect resolves to `v0.7.0`, and a bad repository correctly returns non-zero rather than a bogus tag.
- Fetching `install.sh` at the resolved tag returns the release asset and verifies clean against that release's `checksums.txt`.
- Confirmed in the installer source that `api.github.com` is queried only when `CLAUDE_USAGE_VERSION` is empty, which is now never the case on the resolved path.
- `bash -n` and shellcheck both clean.


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Resolve latest release without GitHub API

- Pin installer and binaries to matching tag

- Preserve fallback when redirect resolution fails

- Document shared-IP rate-limit provisioning fix


___

### Diagram Walkthrough


```mermaid
flowchart LR
  provisioning["Provisioning wrapper"]
  redirect["GitHub latest-release redirect"]
  tag["Resolved release tag"]
  installer["Matching installer and binaries"]
  fallback["Existing API-based fallback"]
  provisioning -- "requests latest release" --> redirect
  redirect -- "provides tag" --> tag
  tag -- "pins version and ref" --> installer
  redirect -- "on resolution failure" --> fallback
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>claude-usage.sh</strong><dd><code>Resolve latest Claude usage release without API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sjust/scripts/claude-usage.sh

<ul><li>Resolves tags through the GitHub release redirect<br> <li> Avoids rate-limited unauthenticated API lookups<br> <li> Uses one tag for installer and binaries<br> <li> Retains existing latest-release fallback behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/595/files#diff-024dcdf00ba60f49c85674e4bad91b5469fa5306ed057d50bcb51e1532ff9673">+18/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document Claude usage provisioning rate-limit fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Documents the shared-runner GitHub API failure<br> <li> Explains redirect-based tag resolution and fallback</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/595/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



---

> Assisted-by: pr-agent/gpt-5.6-sol