### PR TITLE
feat(ghostty): scroll multiplier default and terminal refinements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Changed the managed Ghostty config: `mouse-scroll-multiplier` back to the default of 1, `async-backend = epoll` (Linux; macOS keeps kqueue), SSH TERM compatibility via `shell-integration-features = ssh-env`, the resize overlay hidden, and Shift+Enter / Alt+Shift+Enter sent as CSI-u sequences instead of a literal newline
 - Provisioning now installs the latest `claude-usage` release on every run instead of pinning `v0.6.0`: the version pin and the `creates:` guard are gone, so an already-installed copy is upgraded (currently to `v0.7.0`, which reads limits from the OAuth endpoint and enriches `--status`). The upstream installer short-circuits when the recorded version already matches, so repeated runs stay cheap and the task only reports `changed` when binaries are actually installed
 - Folded Sparkdock Manager upgrade actions into the System status rows and scoped refresh controls to their respective sections
 - Moved the Sparkdock Manager Claude usage refresh control beside its section title and made it more visible

--- a/config/shell/config/ghostty/config
+++ b/config/shell/config/ghostty/config
@@ -16,7 +16,6 @@ font-size = 18
 quit-after-last-window-closed = true
 copy-on-select = clipboard
 confirm-close-surface = false
-mouse-scroll-multiplier = 2
 
 # MacOS Specific
 macos-non-native-fullscreen = true

--- a/config/shell/config/ghostty/config
+++ b/config/shell/config/ghostty/config
@@ -13,6 +13,14 @@ app-notifications = no-clipboard-copy
 font-size = 18
 
 # Usage
+# Fix general slowness on Hyprland (ghostty-org/ghostty#3224); macOS ignores
+# this and always uses kqueue.
+async-backend = epoll
+# Convert TERM to xterm-256color on SSH so remote hosts without ghostty
+# terminfo stop breaking.
+shell-integration-features = ssh-env
+# Hide the resize size popup.
+resize-overlay = never
 quit-after-last-window-closed = true
 copy-on-select = clipboard
 confirm-close-surface = false
@@ -31,4 +39,7 @@ keybind = alt+backspace=text:\x1b\x7f
 keybind = ctrl+shift+n=new_window
 keybind = cmd+c=copy_to_clipboard
 keybind = cmd+v=paste_from_clipboard
-keybind = shift+enter=text:\n
+# Send Shift+Enter and Alt+Shift+Enter as CSI-u so TUIs (Claude Code, tmux,
+# herdr) can distinguish them from plain Enter.
+keybind = shift+enter=csi:13;2u
+keybind = alt+shift+enter=csi:13;4u


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

Closes #604

Two changes to the managed Ghostty config, both cross-platform (verified against the Ghostty reference):

- **Scroll multiplier back to default.** `mouse-scroll-multiplier = 2` doubled every wheel tick before applications saw it; TUIs add their own lines-per-tick policy on top, so vim jumped 6 lines per detent. Users who want faster scrollback can override it in `~/.config/ghostty/user`.
- **Terminal refinements** (from omarchy's Ghostty config):
  - `async-backend = epoll`: fixes general slowness on Hyprland (ghostty-org/ghostty#3224); macOS ignores it and keeps kqueue.
  - `shell-integration-features = ssh-env`: converts TERM to xterm-256color over SSH, so remote hosts without the ghostty terminfo stop breaking.
  - `resize-overlay = never`: hides the resize size popup.
  - Shift+Enter and Alt+Shift+Enter sent as CSI-u, so TUIs (Claude Code, tmux, herdr) can distinguish them from plain Enter; replaces the previous literal-newline bind.