### PR TITLE
feat(harness): tell a relocated skill apart from a removed one

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -365,6 +365,12 @@ Located at `~/.cache/sparkdock/sf-skills-manifest.json`. V2 format with `skills`
 
 `~/.config/sparkdock/harness.json` (version `1`) holds the two per-user opt-in/opt-out lists, written atomically by `bin/common/skill-categories.sh`: `enabled_skill_categories` (which optional categories to install) and `disabled_skills` (which individual skills to keep installed but unlinked). Both readers fail closed — a malformed value aborts the sync rather than silently defaulting to "nothing configured", so a broken file can never re-link a skill the user turned off. The file is created on demand; there is no Ansible task for it.
 
+### Skill Relocation
+
+A skill can move between `skills/system/` and `skills/<category>/` upstream. `cleanup_orphan_skills` in `bin/sparkdock-agents-sync` tells a relocation apart from a removal using `build_upstream_skill_index`, which maps every upstream skill to its owning category whether or not that category is enabled. Moving into an **enabled** category transfers ownership and keeps the install. Moving into a **disabled** one uninstalls the skill, reports it as a migration naming the destination and the `sf-harness-category enable` command, and prints a summary box so it is not lost in a provisioning run. A locally modified skill is kept instead, and `--force` is never suggested for it. Status renders these as `migrated` / `moved to <category>` in the amber tier, not as `orphan`. The reverse direction is handled by `cleanup_optional_skills`.
+
+**Ordering rule for upstream reorganisations:** sparkdock must ship relocation support before the harness moves a skill, because every machine picks the move up on its next sync.
+
 ### Catalog Metadata
 
 The upstream repo provides `config/catalog.json` with short human-friendly descriptions for each system skill and agent. The status script reads this file from the local cache (`~/.cache/sparkdock/agent-skills/config/catalog.json`) to display a DESCRIPTION column in the table. No sync changes are needed — the file is part of the cloned cache.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added skill relocation handling: a skill that moves from `system` into a category is reported as a migration naming the destination category and the command that restores it, instead of as an orphan removed from upstream
+
 - Added a `help` action to `sjust sf-harness-skill` and `sf-harness-category`, reachable as `help`, `-h` or `--help`, which previously failed with a missing-name error
 
 - Added `sjust sf-harness-skill list|enable|disable <skill>` to turn a single AI harness skill off per user; a disabled skill stays installed in `~/.agents/skills/` and only loses its per-tool symlinks, recorded as `disabled_skills` in `~/.config/sparkdock/harness.json`
@@ -189,6 +191,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `sjust sf-skills-status` backward-compatible alias (use `sf-agents-status` instead)
 
 ### Fixed
+
+- Fixed a locally modified skill that moved to another category being told to run `--force`, which would have deleted the local edits rather than restoring the skill
 
 - Fixed the Sparkdock Manager menu showing an outdated Claude Code usage reading (for example a lingering `Credentials expired`) long after the OAuth token was refreshed: usage now re-checks when the menu opens, throttled to the `claude-usage` cache window, in addition to the existing wake and network-change triggers
 - Fixed install-once casks being skipped forever after an interrupted `brew upgrade`. Homebrew moves the app into a Caskroom `.upgrading` staging directory before replacing it, so an upgrade that dies partway leaves an empty `.app` directory behind. The detection step accepted that with a `-d` test, and `brew list --cask` still reported the cask as installed, so provisioning reported success while the app stayed missing. A bundle found at `/Applications` or `~/Applications` now counts as installed only when it carries a `Contents/Info.plist`, and the install step passes `force` so a hollow bundle is replaced instead of aborting the run with "It seems there is already an App at ...". `brew list --cask` remains the fallback for a cask whose bundle is not at either standard path (a custom `HOMEBREW_CASK_OPTS=--appdir=...`, a bundle filed into a subfolder, or an entry declared without an `app` name), so those are not force-reinstalled on every run

--- a/bin/common/skill-categories.sh
+++ b/bin/common/skill-categories.sh
@@ -175,7 +175,7 @@ list_available_skill_categories() {
     local skills_root="${CACHE_DIR}/${SKILLS_ROOT_SUBDIR}"
     local category_dir category
 
-    [[ -d "${skills_root}" ]] || return
+    [[ -d "${skills_root}" ]] || return 0
     for category_dir in "${skills_root}"/*/; do
         [[ -d "${category_dir}" ]] || continue
         category="$(basename "${category_dir}")"

--- a/bin/sparkdock-agents-status
+++ b/bin/sparkdock-agents-status
@@ -30,6 +30,7 @@ HARNESS_RUNNER="$(get_harness_runner)"
 # Skills this user disabled: still installed, but deliberately not linked.
 load_disabled_skill_names
 DISABLED_SKILLS_FOUND=false
+RELOCATIONS_FOUND=false
 
 # Delimiter for table data (tab avoids conflicts with commas in descriptions)
 SEP=$'\t'
@@ -96,6 +97,26 @@ try:
 except Exception:
     print('')
 " "${CATALOG_PATH}" "${section}" "${name}" "${max_len}" 2>/dev/null || echo ""
+}
+
+# Echo the optional category that owns an upstream skill, or nothing. Covers
+# every category on disk, enabled or not, so a skill that moved out of system
+# is not mistaken for one that left upstream.
+# Args: <skill_name>
+find_upstream_category() {
+    local skill_name="$1"
+    local category_dir category
+
+    [[ "${CACHE_AVAILABLE}" == "true" ]] || return 0
+    for category_dir in "${CACHE_DIR}/${SKILLS_ROOT_SUBDIR}"/*/; do
+        [[ -d "${category_dir}" ]] || continue
+        category="$(basename "${category_dir}")"
+        [[ "${category}" == "system" ]] && continue
+        if [[ -f "${category_dir}/${skill_name}/SKILL.md" ]]; then
+            printf '%s\n' "${category}"
+            return
+        fi
+    done
 }
 
 # Check if an upstream resource exists at the given path.
@@ -189,6 +210,8 @@ render_table() {
                 s/\bok\b/\e[38;5;40mok\e[0m/g;
                 s/\boff\b/\e[2moff\e[0m/g;
                 s/\bnative\b/\e[38;5;220mnative\e[0m/g;
+                s/moved to [a-z0-9-]+/\e[38;5;220m$&\e[0m/g;
+                s/\bmigrated\b/\e[38;5;220mmigrated\e[0m/g;
             '
     else
         echo "${csv_data}" | column -t -s $'\t'
@@ -480,6 +503,13 @@ if [[ -d "${SKILLS_DIR}" ]]; then
             if [[ "${CACHE_AVAILABLE}" == "true" ]] && \
                [[ ! -f "${upstream_file}" ]] && \
                [[ "${skill_group}" == "system" || -n "${ENABLED_SKILL_CATEGORIES[${skill_group}]+_}" ]]; then
+                moved_to="$(find_upstream_category "${skill_name}")"
+                if [[ -n "${moved_to}" ]]; then
+                    RELOCATIONS_FOUND=true
+                    append_skill_row "${skill_group}" \
+                        "${skill_name}${SEP}migrated${SEP}moved to ${moved_to}${SEP}${empty_tool_cols}"
+                    continue
+                fi
                 ORPHANS_FOUND=true
                 append_skill_row "${skill_group}" \
                     "${skill_name}${SEP}orphan${SEP}removed from upstream${SEP}${empty_tool_cols}"
@@ -710,6 +740,9 @@ if [[ "${UPDATES_AVAILABLE}" == "true" ]]; then
 fi
 if [[ "${NEW_RESOURCES_AVAILABLE}" == "true" ]]; then
     log_warn "New resources available. Run '${HARNESS_RUNNER} sf-harness-sync' to install."
+fi
+if [[ "${RELOCATIONS_FOUND}" == "true" ]]; then
+    log_warn "Some skills moved to another category. Enable it with '${HARNESS_RUNNER} sf-harness-category enable <category>' to keep using them."
 fi
 if [[ "${DISABLED_SKILLS_FOUND}" == "true" ]] && [[ -d "${HOME}/.config/opencode" ]]; then
     log_warn "OpenCode reads ${SKILLS_DIR} directly, so it still loads disabled skills."

--- a/bin/sparkdock-agents-status
+++ b/bin/sparkdock-agents-status
@@ -99,9 +99,10 @@ except Exception:
 " "${CATALOG_PATH}" "${section}" "${name}" "${max_len}" 2>/dev/null || echo ""
 }
 
-# Echo the optional category that owns an upstream skill, or nothing. Covers
-# every category on disk, enabled or not, so a skill that moved out of system
-# is not mistaken for one that left upstream.
+# Echo the category that owns an upstream skill, or nothing. Covers every
+# category on disk including system, enabled or not, so a skill that moved
+# between categories is not mistaken for one that left upstream. Status can be
+# read before the sync that applies the move, so both directions matter.
 # Args: <skill_name>
 find_upstream_category() {
     local skill_name="$1"
@@ -111,7 +112,6 @@ find_upstream_category() {
     for category_dir in "${CACHE_DIR}/${SKILLS_ROOT_SUBDIR}"/*/; do
         [[ -d "${category_dir}" ]] || continue
         category="$(basename "${category_dir}")"
-        [[ "${category}" == "system" ]] && continue
         if [[ -f "${category_dir}/${skill_name}/SKILL.md" ]]; then
             printf '%s\n' "${category}"
             return
@@ -742,7 +742,7 @@ if [[ "${NEW_RESOURCES_AVAILABLE}" == "true" ]]; then
     log_warn "New resources available. Run '${HARNESS_RUNNER} sf-harness-sync' to install."
 fi
 if [[ "${RELOCATIONS_FOUND}" == "true" ]]; then
-    log_warn "Some skills moved to another category. Enable it with '${HARNESS_RUNNER} sf-harness-category enable <category>' to keep using them."
+    log_warn "Some skills moved to another category. Run '${HARNESS_RUNNER} sf-harness-sync' to apply the move."
 fi
 if [[ "${DISABLED_SKILLS_FOUND}" == "true" ]] && [[ -d "${HOME}/.config/opencode" ]]; then
     log_warn "OpenCode reads ${SKILLS_DIR} directly, so it still loads disabled skills."

--- a/bin/sparkdock-agents-sync
+++ b/bin/sparkdock-agents-sync
@@ -73,6 +73,8 @@ SKILLS_SKIPPED=0
 SKILLS_UNCHANGED=0
 SKILLS_REMOVED=0
 SKILLS_ORPHAN_SKIPPED=0
+SKILLS_RELOCATED=0
+SKILLS_RELOCATION_SKIPPED=0
 AGENTS_ADDED=0
 AGENTS_UPDATED=0
 AGENTS_SKIPPED=0
@@ -315,6 +317,71 @@ sync_skills() {
     if [[ "${found}" = false ]]; then
         log_warn "No valid skills found in '${SYSTEM_SKILLS_SUBDIR}/'."
     fi
+}
+
+# Map every upstream skill name to the category that owns it, for all optional
+# categories whether or not the user enabled them. This is what lets a skill
+# that moved out of system be told apart from one that left upstream entirely.
+declare -A UPSTREAM_SKILL_CATEGORY=()
+
+build_upstream_skill_index() {
+    local category_dir category skill_dir skill_name
+    UPSTREAM_SKILL_CATEGORY=()
+
+    for category_dir in "${CACHE_DIR}/${SKILLS_ROOT_SUBDIR}"/*/; do
+        [[ -d "${category_dir}" ]] || continue
+        category="$(basename "${category_dir}")"
+        [[ "${category}" == "system" ]] && continue
+        validate_skill_category_name "${category}" || continue
+
+        for skill_dir in "${category_dir}"/*/; do
+            [[ -f "${skill_dir}/SKILL.md" ]] || continue
+            skill_name="$(basename "${skill_dir}")"
+            UPSTREAM_SKILL_CATEGORY["${skill_name}"]="${category}"
+        done
+    done
+}
+
+# Categories a skill migrated into during this run, for the closing notice.
+declare -A RELOCATED_INTO_CATEGORY=()
+
+# Handle a managed skill that left system for a category the user has not
+# enabled. Uninstalling is the right end state; being told it vanished from
+# upstream is not.
+# Args: <skill_name> <category>
+handle_relocated_skill() {
+    local skill_name="$1"
+    local category="$2"
+    local target_dir="${SKILLS_TARGET_DIR}/${skill_name}"
+
+    if [[ -f "${target_dir}/SKILL.md" ]]; then
+        local installed_sha manifest_sha
+        installed_sha="$(compute_sha256 "${target_dir}/SKILL.md")"
+        manifest_sha="$(manifest_get_sha "skills" "${skill_name}")"
+
+        if [[ -n "${manifest_sha}" ]] && [[ "${manifest_sha}" != "${installed_sha}" ]] && [[ "${FORCE}" != true ]]; then
+            SKILLS_RELOCATION_SKIPPED=$((SKILLS_RELOCATION_SKIPPED + 1))
+            RELOCATED_INTO_CATEGORY["${category}"]=1
+            log_warn "Skill moved to the ${category} category and is locally modified, so it was kept: ${skill_name}"
+            return
+        fi
+    fi
+
+    if [[ -d "${target_dir}" ]]; then
+        local resolved_path resolved_base
+        resolved_path="$(cd "${target_dir}" 2>/dev/null && pwd -P)" || resolved_path=""
+        resolved_base="$(cd "${SKILLS_TARGET_DIR}" 2>/dev/null && pwd -P)" || resolved_base=""
+        if [[ -z "${resolved_path}" || -z "${resolved_base}" || "${resolved_path}" != "${resolved_base}/"* ]]; then
+            log_error "refusing to remove path outside skills directory: ${target_dir}"
+            return
+        fi
+        rm -rf "${resolved_path}"
+    fi
+
+    manifest_remove "skills" "${skill_name}"
+    SKILLS_RELOCATED=$((SKILLS_RELOCATED + 1))
+    RELOCATED_INTO_CATEGORY["${category}"]=1
+    log_info "Skill moved from system to the ${category} category: ${skill_name}"
 }
 
 # Prepare enabled optional skills and reject flat-install name collisions before
@@ -799,6 +866,14 @@ cleanup_orphan_skills() {
             continue
         fi
 
+        # The skill left system for a category the user has not enabled. That is
+        # a migration, not a disappearance, so it is reported as one.
+        local relocated_category="${UPSTREAM_SKILL_CATEGORY[${skill_name}]:-}"
+        if [[ -n "${relocated_category}" ]]; then
+            handle_relocated_skill "${skill_name}" "${relocated_category}"
+            continue
+        fi
+
         local target_dir="${SKILLS_TARGET_DIR}/${skill_name}"
 
         # Check if user has locally modified the orphaned skill
@@ -955,8 +1030,34 @@ cleanup_orphan_agents() {
 
 # --- Summary ---
 
+# Announce skills that changed category during this run. A migration is easy to
+# miss in a long provisioning run, so it gets its own box rather than a log line.
+print_relocation_notice() {
+    [[ ${#RELOCATED_INTO_CATEGORY[@]} -gt 0 ]] || return 0
+
+    local runner category
+    runner="$(get_harness_runner)"
+
+    local notice="Skills moved to another category\n"
+    notice+="\nUpstream made these skills optional and moved them out of the"
+    notice+="\nrequired set. Their categories are not enabled here.\n"
+    if [[ "${SKILLS_RELOCATED}" -gt 0 ]]; then
+        notice+="\n  ${SKILLS_RELOCATED} uninstalled"
+    fi
+    if [[ "${SKILLS_RELOCATION_SKIPPED}" -gt 0 ]]; then
+        notice+="\n  ${SKILLS_RELOCATION_SKIPPED} kept, because you modified them locally"
+    fi
+    notice+="\n\nEnable a category to manage its skills again:\n"
+    for category in $(printf '%s\n' "${!RELOCATED_INTO_CATEGORY[@]}" | sort); do
+        notice+="\n  ${runner} sf-harness-category enable ${category}"
+    done
+
+    echo ""
+    print_summary_box "$(printf '%b' "${notice}")"
+}
+
 print_summary() {
-    local skills_total=$((SKILLS_ADDED + SKILLS_UPDATED + SKILLS_SKIPPED + SKILLS_UNCHANGED + SKILLS_REMOVED + SKILLS_ORPHAN_SKIPPED))
+    local skills_total=$((SKILLS_ADDED + SKILLS_UPDATED + SKILLS_SKIPPED + SKILLS_UNCHANGED + SKILLS_REMOVED + SKILLS_ORPHAN_SKIPPED + SKILLS_RELOCATED + SKILLS_RELOCATION_SKIPPED))
     local agents_total=$((AGENTS_ADDED + AGENTS_UPDATED + AGENTS_SKIPPED + AGENTS_UNCHANGED + AGENTS_REMOVED + AGENTS_ORPHAN_SKIPPED))
     local total=$((skills_total + agents_total))
 
@@ -970,6 +1071,8 @@ print_summary() {
         [[ "${SKILLS_REMOVED}" -gt 0 ]] && summary+=" ${SKILLS_REMOVED} removed,"
         [[ "${SKILLS_SKIPPED}" -gt 0 ]] && summary+=" ${SKILLS_SKIPPED} skipped,"
         [[ "${SKILLS_ORPHAN_SKIPPED}" -gt 0 ]] && summary+=" ${SKILLS_ORPHAN_SKIPPED} orphan-skipped,"
+        [[ "${SKILLS_RELOCATED}" -gt 0 ]] && summary+=" ${SKILLS_RELOCATED} migrated,"
+        [[ "${SKILLS_RELOCATION_SKIPPED}" -gt 0 ]] && summary+=" ${SKILLS_RELOCATION_SKIPPED} migrated-kept,"
         [[ "${SKILLS_UNCHANGED}" -gt 0 ]] && summary+=" ${SKILLS_UNCHANGED} unchanged,"
         summary="${summary%,}\n"
     fi
@@ -1007,6 +1110,8 @@ print_summary() {
         log_info "Some resources were skipped due to local modifications."
         log_info "Run '${SCRIPT_NAME} --force' to overwrite them."
     fi
+
+    print_relocation_notice
 
     local total_orphan_skipped=$((SKILLS_ORPHAN_SKIPPED + AGENTS_ORPHAN_SKIPPED))
     if [[ "${total_orphan_skipped}" -gt 0 ]]; then
@@ -1124,6 +1229,10 @@ main() {
 
     # Clone or update the repo
     sync_repo
+
+    # Index every upstream category so a relocated skill is not mistaken for
+    # one that left upstream.
+    build_upstream_skill_index
 
     if [[ "${CATEGORY_ACTION}" == "list" ]]; then
         print_skill_categories

--- a/sjust/scripts/lib/test_skill_categories.py
+++ b/sjust/scripts/lib/test_skill_categories.py
@@ -166,6 +166,99 @@ class SkillCategoryIntegrationTest(unittest.TestCase):
             r"\s+->\s+~/.external/linked-skill\s+ok\s+-\s+ok",
         )
 
+    def add_system_skill(self, name: str) -> None:
+        """Commit another system skill, so a relocation does not empty the category."""
+        self.write_skill("system", name)
+        self.git("add", ".")
+        self.git("commit", "-m", f"add {name}")
+
+    def relocate_skill(self, name: str, source: str, destination: str) -> None:
+        """Move a skill between categories upstream, as a real reorganisation would."""
+        destination_dir = self.upstream / "skills" / destination
+        destination_dir.mkdir(parents=True, exist_ok=True)
+        self.git(
+            "mv",
+            f"skills/{source}/{name}",
+            f"skills/{destination}/{name}",
+        )
+        self.git("commit", "-m", f"move {name} to {destination}")
+
+    def test_relocated_skill_is_reported_as_a_migration_not_an_orphan(self) -> None:
+        self.add_system_skill("keeper")
+        self.run_sync()
+        self.assertTrue((self.home / ".agents" / "skills" / "core").is_dir())
+        self.assertTrue((self.home / ".claude" / "skills" / "core").is_symlink())
+
+        self.relocate_skill("core", "system", "security")
+        result = self.run_sync()
+        output = ANSI_ESCAPE.sub("", result.stdout + result.stderr)
+
+        # Gone, which is right: the category is not enabled.
+        self.assertFalse((self.home / ".agents" / "skills" / "core").exists())
+        self.assertFalse((self.home / ".claude" / "skills" / "core").exists())
+        self.assertNotIn("core", self.read_manifest()["skills"])
+
+        # Reported as what it is, with the way back.
+        self.assertIn("Skill moved from system to the security category: core", output)
+        self.assertIn("sf-harness-category enable security", output)
+        self.assertNotIn("no longer in upstream", output)
+
+    def test_a_modified_relocated_skill_is_kept_without_suggesting_force(self) -> None:
+        self.add_system_skill("keeper")
+        self.run_sync()
+        skill_md = self.home / ".agents" / "skills" / "core" / "SKILL.md"
+        skill_md.write_text(skill_md.read_text() + "\nlocal note\n")
+
+        self.relocate_skill("core", "system", "security")
+        result = self.run_sync()
+        output = ANSI_ESCAPE.sub("", result.stdout + result.stderr)
+
+        self.assertTrue(skill_md.is_file())
+        self.assertIn("local note", skill_md.read_text())
+        self.assertIn("locally modified, so it was kept: core", output)
+        self.assertIn("kept, because you modified them locally", output)
+        self.assertNotIn("--force", output)
+
+    def test_a_skill_that_really_left_upstream_is_still_an_orphan(self) -> None:
+        self.add_system_skill("keeper")
+        self.run_sync()
+
+        self.git("rm", "-rq", "skills/system/core")
+        self.git("commit", "-m", "drop core")
+        result = self.run_sync()
+        output = ANSI_ESCAPE.sub("", result.stdout + result.stderr)
+
+        self.assertIn("Orphan removed: core (no longer in upstream)", output)
+        self.assertNotIn("moved from system", output)
+        self.assertFalse((self.home / ".agents" / "skills" / "core").exists())
+
+    def test_relocation_into_an_enabled_category_transfers_ownership(self) -> None:
+        self.add_system_skill("keeper")
+        self.run_sync("category", "enable", "angular")
+        self.relocate_skill("core", "system", "angular")
+
+        self.run_sync()
+
+        # Still installed, now owned by the category rather than by system.
+        self.assertTrue((self.home / ".agents" / "skills" / "core").is_dir())
+        manifest = self.read_manifest()
+        self.assertNotIn("core", manifest["skills"])
+        self.assertIn("angular/core", manifest["optional_skills"])
+
+    def test_status_shows_a_relocated_skill_as_migrated(self) -> None:
+        self.add_system_skill("keeper")
+        self.run_sync()
+        skill_md = self.home / ".agents" / "skills" / "core" / "SKILL.md"
+        skill_md.write_text(skill_md.read_text() + "\nlocal note\n")
+        self.relocate_skill("core", "system", "security")
+        self.run_sync()
+
+        output = self.run_status()
+
+        self.assertRegex(output, r"core\s+migrated\s+moved to security")
+        self.assertNotIn("removed from upstream", output)
+        self.assertIn("Some skills moved to another category", output)
+
     def run_status(self) -> str:
         status = subprocess.run(
             [str(STATUS_SCRIPT)],

--- a/sjust/scripts/lib/test_skill_categories.py
+++ b/sjust/scripts/lib/test_skill_categories.py
@@ -195,7 +195,11 @@ class SkillCategoryIntegrationTest(unittest.TestCase):
 
         # Gone, which is right: the category is not enabled.
         self.assertFalse((self.home / ".agents" / "skills" / "core").exists())
-        self.assertFalse((self.home / ".claude" / "skills" / "core").exists())
+        # lexists, not exists: a dangling symlink is not "gone", and exists()
+        # follows the link and would report it as absent either way.
+        for tool in ("claude", "copilot"):
+            link = self.home / f".{tool}" / "skills" / "core"
+            self.assertFalse(os.path.lexists(link), f"{tool} link survived")
         self.assertNotIn("core", self.read_manifest()["skills"])
 
         # Reported as what it is, with the way back.
@@ -244,6 +248,29 @@ class SkillCategoryIntegrationTest(unittest.TestCase):
         manifest = self.read_manifest()
         self.assertNotIn("core", manifest["skills"])
         self.assertIn("angular/core", manifest["optional_skills"])
+
+    def test_status_reports_a_move_into_system_before_the_sync_applies_it(
+        self,
+    ) -> None:
+        self.add_system_skill("keeper")
+        self.run_sync("category", "enable", "angular")
+        self.relocate_skill("angular-developer", "angular", "system")
+
+        # Status refreshes the cache but does not sync, so this is the window
+        # where the skill sits upstream in a different category than the
+        # manifest records. run_status() pins the cache with SPARKDOCK_SKIP_FETCH,
+        # which would hide the move, so let this one fetch as it does in real use.
+        status = subprocess.run(
+            [str(STATUS_SCRIPT)],
+            env=self.environment,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        output = ANSI_ESCAPE.sub("", status.stdout + status.stderr).replace("│", " ")
+
+        self.assertRegex(output, r"angular-developer\s+migrated\s+moved to system")
+        self.assertNotIn("removed from upstream", output)
 
     def test_status_shows_a_relocated_skill_as_migrated(self) -> None:
         self.add_system_skill("keeper")


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

Closes #616

Generic mechanism for skills that move between categories upstream. Prompted by an upcoming `security` category in sf-agents-harness, but nothing here is specific to it.

## The defect

`cleanup_orphan_skills` treated any manifest entry missing from `skills/system/` as an orphan, with one exception for a name adopted by an **enabled** category. A disabled category was invisible to it, so a skill that had merely moved took the orphan path. Verified on fixtures:

- **Clean skill:** deleted, logged as `Orphan removed: <name> (no longer in upstream)`. False, and silent about how to get it back.
- **Locally modified:** kept, still symlinked, still manifest-tracked as system-owned, with `--force` as the only offered remedy. That deletes the user's edits. The action that helps, `sf-harness-category enable <category>`, was never mentioned.
- **Status:** red `orphan / removed from upstream`, on the same screen as a category table already showing the destination category as `optional / disabled`.

## The fix

`build_upstream_skill_index` maps every upstream skill to its owning category regardless of enablement. That was the only missing input; the cache already holds every category on disk.

A relocation into a disabled category keeps the same **end state** as before, uninstalled, because the category is not enabled and that is what optional means. What changes is that the user is told:

```
 ┌─────────────────────────────────────────────────────────────────┐
 │  Skills moved to another category                               │
 │                                                                 │
 │  Upstream made these skills optional and moved them out of the  │
 │  required set. Their categories are not enabled here.           │
 │                                                                 │
 │    1 uninstalled                                                │
 │    1 kept, because you modified them locally                    │
 │                                                                 │
 │  Enable a category to manage its skills again:                  │
 │                                                                 │
 │    ajust sf-harness-category enable security                    │
 └─────────────────────────────────────────────────────────────────┘
```

A box rather than a log line, because a migration is easy to miss in a provisioning run. The counts are conditional, so the text never claims a kept skill was uninstalled. Status gained `migrated` / `moved to <category>` in the amber tier, plus a footer naming the command.

Genuine removals are untouched and still report as orphans.

## Two bare returns

`print_relocation_notice` began with `[[ ... ]] || return`, which propagates the failed test's status. It runs last in `main`, so **every sync exited 1** once it existed. Caught by the existing suite rather than by review, which is the argument for the suite.

The same shape sits in `list_available_skill_categories` and predates this change: it would abort `category list` on a machine with no cached skills root. Fixed in passing, one word.

## Verification

`just test-python`: 93 tests, all passing. Five are new, and each was confirmed to **fail against master** with the old wrong messages visible in the failure output:

- relocation into a disabled category reports a migration, not an orphan, and never says `no longer in upstream`
- a modified relocated skill is kept and the output contains no `--force`
- a skill that genuinely left upstream still reports as an orphan
- relocation into an **enabled** category still transfers ownership, as a regression guard
- status shows `migrated` / `moved to security` and no `removed from upstream`

Fixtures keep a second system skill behind, so a relocation is a partial reorganisation rather than one that empties the category.

Also run: `bash -n` on all three scripts, shellcheck with no new findings beyond the pre-existing `SC1091`/`SC2004`/`SC2153`, ruff, prettier.

## Known rough edge, pre-existing

Enabling a category that adopts a **locally modified** skill leaves that skill installed but untracked, because `sync_skill` skips the conflict and the ownership transfer has already dropped the system entry. Status labels it `unmanaged / conflicts with upstream`, which is true. Confirmed identical on `master`, so it is not a regression here.

## Ordering

The harness move must not land until this ships. The harness is a live dependency: the moment it hits `main`, every machine picks it up on the next sync.


___

### **PR Type**
Enhancement, Bug fix, Tests, Documentation


___

### **Description**
- Detect relocations across all upstream categories

- Preserve modified skills without force guidance

- Surface migrations in sync and status

- Add regression coverage and operational documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  cache["All upstream skill categories"]
  index["Skill ownership index"]
  sync["Skill synchronization"]
  disabled["Disabled destination category"]
  enabled["Enabled destination category"]
  status["Migrated status and recovery guidance"]
  cache -- "builds" --> index
  index -- "informs" --> sync
  sync -- "uninstall or preserve edits" --> disabled
  sync -- "transfer ownership" --> enabled
  disabled -- "report migration" --> status
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>skill-categories.sh</strong><dd><code>Make missing category cache return successfully</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bin/common/skill-categories.sh

<ul><li>Return success when the cached skills root is absent.<br> <li> Prevent category listing from aborting its caller.</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/617/files#diff-384d3dbf4877d407cb2b45874ce317a3e1ea4abe9d9e02e56f0ed556e71e75d3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sparkdock-agents-sync</strong><dd><code>Detect and safely process upstream skill relocations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bin/sparkdock-agents-sync

<ul><li>Index skills across enabled and disabled upstream categories.<br> <li> Uninstall clean relocations while preserving local modifications.<br> <li> Transfer ownership when destination categories are enabled.<br> <li> Add migration counters, logs, and recovery summary notices.</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/617/files#diff-a4937e767294b298c6848cc2d41a4c546ec326540e29b9720d75bc2fa99457ca">+110/-1</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_skill_categories.py</strong><dd><code>Cover skill relocation synchronization and status behavior</code></dd></summary>
<hr>

sjust/scripts/lib/test_skill_categories.py

<ul><li>Add helpers for creating and relocating upstream skills.<br> <li> Test disabled-category removal and modified-skill preservation.<br> <li> Verify enabled-category ownership transfer and genuine orphan <br>handling.<br> <li> Confirm status displays relocated skills as migrations.</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/617/files#diff-88c6fd018409295cbe6f4f9ae3508b81ab5690ff6ccf12a7617af59b8e913e1d">+93/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AGENTS.md</strong><dd><code>Document skill relocation behavior and rollout ordering</code>&nbsp; &nbsp; </dd></summary>
<hr>

AGENTS.md

<ul><li>Document category-independent skill relocation detection.<br> <li> Explain enabled, disabled, and locally modified outcomes.<br> <li> Record deployment ordering requirements for upstream reorganizations.</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/617/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Record skill relocation handling and safety fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Announce destination-aware skill migration reporting.<br> <li> Record removal of unsafe <code>--force</code> guidance.</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/617/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sparkdock-agents-status</strong><dd><code>Show relocated skills as actionable migration warnings</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bin/sparkdock-agents-status

<ul><li>Find relocated skills across every cached optional category.<br> <li> Render <code>migrated</code> and destination details in amber.<br> <li> Provide category enablement guidance instead of orphan warnings.</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/617/files#diff-892705812183d1227f4f4c4df5e2f0a5b3b3d2ef1c7978d57223d2b4c85787ab">+33/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



---

> Assisted-by: pr-agent/gpt-5.6-sol