### PR TITLE
feat(shell): add the sproxy alias for spark-http-proxy

### DIFF
--- a/.github/workflows/test-sjust.yml
+++ b/.github/workflows/test-sjust.yml
@@ -66,6 +66,11 @@ jobs:
           # 00-default.just and so cannot be parsed standalone. It is exercised
           # via the unified justfile a few lines above and `--evaluate` below.
 
+      - name: Syntax check the shared shell config
+        run: |
+          zsh -n config/shell/aliases.zsh
+          zsh -n config/shell/sparkdock.zshrc
+
       - name: Test skill category scripts
         run: |
           bash -n \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added the `sproxy` shell alias for `spark-http-proxy`, available on macOS and Linux wherever the proxy CLI is installed
+
 - Added skill relocation handling: a skill that moves from `system` into a category is reported as a migration naming the destination category and the command that restores it, instead of as an orphan removed from upstream
 
 - Added a `help` action to `sjust sf-harness-skill` and `sf-harness-category`, reachable as `help`, `-h` or `--help`, which previously failed with a missing-name error

--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ spark-http-proxy stop    # Stop proxy services
 spark-http-proxy status  # Check service status
 ```
 
+`sproxy` is a shorter alias for the same command, so `sproxy status` works too.
+
 ### Menu Bar App
 
 Sparkdock includes a native macOS menu bar application that provides quick access to system status and common tasks:

--- a/config/shell/aliases.zsh
+++ b/config/shell/aliases.zsh
@@ -281,6 +281,13 @@ if command_exists openspec; then
   alias osa='openspec archive'
 fi
 
+# Spark HTTP proxy
+# Zsh completes through the alias expansion, so 'sproxy sta<TAB>' still works
+# wherever 'spark-http-proxy install-completion' has run.
+if command_exists spark-http-proxy; then
+  alias sproxy='spark-http-proxy'
+fi
+
 # Directory navigation
 alias ..='cd ..'
 alias ...='cd ../..'


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

Closes #618

`spark-http-proxy` is 16 characters before you reach a subcommand, and it gets typed constantly during local development.

```bash
sproxy status
sproxy start
```

## The name

`sproxy` follows the contraction this repo already uses: `sjust` is spark just, `ajust` its SparkFabrik sibling. So `sproxy` : `proxy` :: `sjust` : `just`. It is unreferenced anywhere in this repo and free on a provisioned machine.

## Why an alias rather than a symlink

A second `ln -sf` in `/usr/local/bin` would make `sproxy` a real command, visible to scripts, to `command -v`, and to shells other than zsh. That is genuinely better, and it is not what this does, because the symlink for `spark-http-proxy` is created in **three** separate places:

| Where | Target |
| --- | --- |
| `sparkfabrik/http-proxy`, `bin/install.sh` line 168 | `$BIN_DIR/spark-http-proxy` |
| this repo, `ansible/macos/macos/base.yml` | `{{ dev_env_dir }}/http-proxy/bin/spark-http-proxy` |
| `archlinux-provisioner` | `~/.local/spark/http-proxy/src/bin/spark-http-proxy` |

Adding it to one of those reaches only some machines; covering everyone means three repositories kept in step. `config/shell/aliases.zsh` is sourced on both macOS and Linux, so one line covers every machine today. The tradeoff is that `sproxy` is interactive zsh only: scripts and bash still need the full name.

If we later decide it should be a real command, the alias is harmless alongside a symlink to the same target.

## Completion

Unaffected. Zsh completes a simple alias through its expansion, so `sproxy sta<TAB>` keeps working wherever `spark-http-proxy install-completion` has run.

## Verified

Sourced the file and ran the alias against the live proxy on a real machine:

```
$ eval "sproxy status"
ℹ  HTTP Proxy Status
==================================
✅ HTTP Proxy is running
   🌐 Traefik Dashboard: http://localhost:30000
```

The `eval` is only needed for the test: zsh expands aliases when it parses the whole `-c` string, before `source` has run, so a direct `sproxy status` in the same invocation reports command not found. In a real shell the file is sourced at startup and the alias is available normally.

## One thing found on the way

`config/shell/aliases.zsh` had **no syntax gate in CI**, despite being sourced into every shell on both operating systems. A broken edit there would have shipped and greeted everyone with a parse error at their next prompt. The workflow now runs `zsh -n` over it and over `sparkdock.zshrc`; both parse clean today.


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Add guarded `sproxy` alias for proxy CLI

- Validate shared Zsh configuration syntax in CI

- Document alias usage and release addition


___

### Diagram Walkthrough


```mermaid
flowchart LR
  shellConfig["Shared Zsh configuration"]
  detection["Proxy CLI detection"]
  alias["sproxy alias"]
  proxyCLI["spark-http-proxy CLI"]
  workflow["CI syntax checks"]
  shellConfig -- "checks availability" --> detection
  detection -- "defines" --> alias
  alias -- "expands to" --> proxyCLI
  workflow -- "validates" --> shellConfig
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>aliases.zsh</strong><dd><code>Add guarded alias for Spark HTTP proxy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config/shell/aliases.zsh

<ul><li>Detects whether <code>spark-http-proxy</code> is installed<br> <li> Defines <code>sproxy</code> as its shorter alias<br> <li> Notes that Zsh completion remains available</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/619/files#diff-fe1e4df088c825fe14cb629660151d77d5debec9455646f03c762f2aefb8f03a">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test-sjust.yml</strong><dd><code>Validate shared Zsh configuration syntax in CI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/test-sjust.yml

<ul><li>Runs <code>zsh -n</code> against shared aliases<br> <li> Syntax-checks the main Sparkdock Zsh configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/619/files#diff-6778ce9799b981b37415145031aab5b35494f9f30f961d1bf744f6599882de21">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Record new proxy alias in changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

- Records the cross-platform `sproxy` alias addition


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/619/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document shorter Spark HTTP proxy command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Documents <code>sproxy</code> as shorthand for <code>spark-http-proxy</code><br> <li> Includes <code>sproxy status</code> as an usage example</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/619/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



---

> Assisted-by: pr-agent/gpt-5.6-sol