### PR TITLE
fix(harness): skip gum spinner on gum 2.x to stop terminal query leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed stray terminal query replies (such as `2026;2$y`) appearing at the shell prompt after `sf-harness-sync` and other spinner-wrapped commands: `run_with_spinner` skips `gum spin` on gum 2.x, which probes the terminal at startup and can exit before consuming the replies
+
 - Fixed a locally modified skill that moved to another category being told to run `--force`, which would have deleted the local edits rather than restoring the skill
 
 - Fixed the Sparkdock Manager menu showing an outdated Claude Code usage reading (for example a lingering `Credentials expired`) long after the OAuth token was refreshed: usage now re-checks when the menu opens, throttled to the `claude-usage` cache window, in addition to the existing wake and network-change triggers

--- a/bin/common/utils.sh
+++ b/bin/common/utils.sh
@@ -20,11 +20,32 @@ print() { log_info "$1"; }
 
 # --- Higher-level output helpers ---
 
-# Run a command with a gum spinner (falls back to plain log + execution)
+# gum 2.x (Bubble Tea v2) probes the terminal at startup (DECRQM modes 2026
+# and 2027, kitty keyboard protocol). When the wrapped command finishes
+# quickly, `gum spin` exits before consuming the replies, which stay in the
+# tty input buffer and are echoed at the next shell prompt as stray
+# characters such as "2026;2$y". Only `gum spin` is affected: `gum style`
+# and `gum log` do not send these queries.
+# See: https://github.com/sparkfabrik/sparkdock/issues/620
+gum_spin_is_safe() {
+    if [[ -z "${GUM_SPIN_SAFE:-}" ]]; then
+        local gum_major
+        gum_major="$(gum --version 2>/dev/null | sed -nE 's/^gum version v?([0-9]+).*/\1/p')"
+        if [[ "${gum_major}" =~ ^[0-9]+$ ]] && [[ "${gum_major}" -lt 2 ]]; then
+            GUM_SPIN_SAFE=true
+        else
+            GUM_SPIN_SAFE=false
+        fi
+    fi
+    [[ "${GUM_SPIN_SAFE}" = true ]]
+}
+
+# Run a command with a gum spinner (falls back to plain log + execution).
+# The spinner is skipped on gum >= 2 until the upstream query leak is fixed.
 run_with_spinner() {
     local title="$1"
     shift
-    if [[ "${HAS_GUM}" = true ]]; then
+    if [[ "${HAS_GUM}" = true ]] && gum_spin_is_safe; then
         gum spin --spinner dot --title "${title}" -- "$@"
     else
         log_info "${title}"


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @mcefala._

## Summary

After `sjust sf-harness-sync` finishes, stray characters such as `2026;2$y` appear at the shell prompt. gum 2.0 (Bubble Tea v2) probes the terminal at startup with DECRQM queries for modes 2026 and 2027 and the kitty keyboard protocol (`ESC[?u`). When the command wrapped by `gum spin` finishes quickly, gum exits before consuming the replies, which stay in the tty input buffer and are echoed at the next prompt.

Closes #620.

## Changes

- **`bin/common/utils.sh`.** Adds `gum_spin_is_safe`, which parses the installed gum major version once and caches the result. `run_with_spinner` now uses the plain `log_info` fallback on gum 2.x, and keeps the spinner on gum 0.x/1.x. `gum style` and `gum log` do not send these queries, so all other gum styling is untouched.
- **`CHANGELOG.md`.** Adds a Fixed entry under Unreleased.

## Verification

- `bash -n` and `shellcheck` pass on the patched `utils.sh`.
- `run_with_spinner` executed under a pty with gum 2.0.0 emits no `ESC[?2026$p` / `ESC[?2027$p` / `ESC[?u` queries (before the patch it did, captured with `script` + `od`).
- `gum_spin_is_safe` reports unsafe on gum 2.0.0 and the wrapped command still runs and propagates its exit status.

The version gate can be dropped once the upstream Bubble Tea v2 regression is fixed in a gum release.


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Disable unsafe spinners on gum 2.x

- Preserve spinner behavior on earlier versions

- Cache parsed gum version safety

- Document terminal query leak fix


___

### Diagram Walkthrough


```mermaid
flowchart LR
  request["Run spinner-wrapped command"]
  check["Check installed gum major version"]
  safe["Use gum spinner on gum 0.x or 1.x"]
  unsafe["Use plain logging on gum 2.x or unknown"]
  command["Execute wrapped command"]
  request -- "requests output helper" --> check
  check -- "safe" --> safe
  check -- "unsafe" --> unsafe
  safe -- "runs" --> command
  unsafe -- "runs" --> command
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.sh</strong><dd><code>Gate spinner usage by gum major version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bin/common/utils.sh

<ul><li>Add cached <code>gum_spin_is_safe</code> version check<br> <li> Treat gum 2.x and unknown versions unsafe<br> <li> Fall back to logging without <code>gum spin</code><br> <li> Preserve wrapped command execution and status</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/621/files#diff-0e519661e53f442cf4e168f2abea58548b5f1c9358f55fc54b6fc77363c56a33">+23/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document gum spinner query leak fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Document the gum 2.x terminal reply leak<br> <li> Note spinner fallback for affected commands</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/sparkdock/pull/621/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



---

> Assisted-by: pr-agent/gpt-5.6-sol